### PR TITLE
Fix: Update LineNumberArea and enhance install.sh

### DIFF
--- a/include/LineNumberArea.h
+++ b/include/LineNumberArea.h
@@ -2,13 +2,15 @@
 #define LINENUMBERAREA_H
 
 #include <QWidget>
-#include <QTextEdit> // Or forward-declare if only pointers/references are used in header
+#include <QTextEdit>
+#include <QPaintEvent>
 
-class LineNumberArea : public QWidget {
+class LineNumberArea : public QWidget
+{
     Q_OBJECT
-
 public:
-    LineNumberArea(QTextEdit *editor);
+    explicit LineNumberArea(QTextEdit *editor);
+    ~LineNumberArea() override;
 
     QSize sizeHint() const override;
 
@@ -18,10 +20,10 @@ protected:
 private slots:
     void updateLineNumberAreaWidth(int newBlockCount);
     void updateLineNumberArea(const QRect &rect, int dy);
-    void updateLineNumberAreaOnScroll(); // Custom slot for scrollbar valueChanged
+    void updateLineNumberAreaOnScroll();
 
 private:
-    int lineNumberAreaWidth(); // Helper function to calculate width
+    int lineNumberAreaWidth();
     QTextEdit *codeEditor;
 };
 

--- a/install.sh
+++ b/install.sh
@@ -1,23 +1,89 @@
 #!/bin/bash
 
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
 # 1. Check for root privileges
 if [ "$EUID" -ne 0 ]; then
   echo "Please run this script with sudo: sudo ./install.sh"
   exit 1
 fi
 
-# 2. Define the .deb package path
-DEB_PACKAGE="build_temp/alte-0.1.0-Linux.deb"
+# 2. Define the .deb package path and related variables
+DEB_PACKAGE_NAME="alte-0.1.0-Linux.deb"
+BUILD_DIR="build_temp"
+DEB_PACKAGE_PATH="$BUILD_DIR/$DEB_PACKAGE_NAME"
+REBUILD_FLAG=false
 
-# 3. Check if the .deb package exists
-if [ ! -f "$DEB_PACKAGE" ]; then
-  echo "Error: $DEB_PACKAGE not found."
-  echo "Please build the package first. Refer to README.md for build instructions."
-  exit 1
+# Parse arguments
+for arg in "$@"
+do
+    if [ "$arg" == "--rebuild" ]
+    then
+        REBUILD_FLAG=true
+        echo "Rebuild flag detected. Forcing a rebuild of the package."
+    fi
+done
+
+# 3. Check if the .deb package exists or if rebuild is forced
+if [ "$REBUILD_FLAG" = true ] || [ ! -f "$DEB_PACKAGE_PATH" ]; then
+  if [ "$REBUILD_FLAG" = true ]; then
+    echo "Rebuilding package as requested..."
+  else
+    echo "$DEB_PACKAGE_PATH not found. Attempting to build it..."
+  fi
+
+  ORIGINAL_PWD=$(pwd)
+
+  echo "Creating build directory: $BUILD_DIR"
+  mkdir -p "$BUILD_DIR"
+
+  echo "Changing directory to $BUILD_DIR"
+  cd "$BUILD_DIR"
+
+  echo "Running CMake..."
+  if cmake ..; then
+    echo "CMake configuration successful."
+  else
+    echo "CMake configuration failed. Please check the output above."
+    cd "$ORIGINAL_PWD"
+    exit 1
+  fi
+
+  echo "Building project using make..."
+  if make -j$(nproc); then
+    echo "Project build successful."
+  else
+    echo "Project build failed. Please check the output above."
+    cd "$ORIGINAL_PWD"
+    exit 1
+  fi
+
+  echo "Generating Debian package using CPack..."
+  if cpack -G DEB; then
+    echo "Debian package generation successful."
+  else
+    echo "Debian package generation failed. Please check the output above."
+    cd "$ORIGINAL_PWD"
+    exit 1
+  fi
+
+  echo "Changing directory back to $ORIGINAL_PWD"
+  cd "$ORIGINAL_PWD"
+
+  if [ ! -f "$DEB_PACKAGE_PATH" ]; then
+    echo "Error: $DEB_PACKAGE_PATH still not found after build attempt."
+    echo "Please check the build logs in the $BUILD_DIR directory."
+    exit 1
+  else
+    echo "Successfully built $DEB_PACKAGE_PATH."
+  fi
+else
+  echo "$DEB_PACKAGE_PATH found."
 fi
 
 # 4. Confirm installation
-echo "Found $DEB_PACKAGE."
+echo "Found $DEB_PACKAGE_PATH."
 read -p "Proceed with installation? (y/N) " confirm
 if [[ "$confirm" != [yY] ]]; then
   echo "Installation cancelled."
@@ -25,13 +91,10 @@ if [[ "$confirm" != [yY] ]]; then
 fi
 
 # 5. Install the package
-echo "Installing $DEB_PACKAGE..."
-if dpkg -i "$DEB_PACKAGE"; then
-  echo "$DEB_PACKAGE installed or updated."
-else
-  echo "Error during dpkg installation. Attempting to fix dependencies..."
-  # Proceed to dependency fixing even if dpkg reports an error, as it's often due to missing dependencies.
-fi
+echo "Installing $DEB_PACKAGE_PATH..."
+# The initial dpkg -i command might fail if dependencies are missing.
+# We capture its exit code but proceed to apt-get -f install regardless.
+dpkg -i "$DEB_PACKAGE_PATH" || true
 
 # 6. Fix dependencies
 echo "Attempting to fix any missing dependencies..."
@@ -44,7 +107,7 @@ fi
 
 echo "Running apt-get install -f -y..."
 if apt-get install -f -y; then
-  echo "Installation complete!"
+  echo "Installation complete! Alte editor should now be installed."
 else
   echo "Dependency resolution failed. You may need to resolve dependencies manually."
   exit 1

--- a/src/LineNumberArea.cpp
+++ b/src/LineNumberArea.cpp
@@ -1,41 +1,31 @@
-#include "LineNumberArea.h" // Will be found due to include_directories(include)
+#include "LineNumberArea.h"
 #include <QPainter>
 #include <QTextBlock>
 #include <QScrollBar>
-#include <QAbstractTextDocumentLayout> // Required for documentLayout
-#include <QDebug> // For debugging output
+#include <QAbstractTextDocumentLayout>
+#include <QDebug>
 
 LineNumberArea::LineNumberArea(QTextEdit *editor) : QWidget(editor), codeEditor(editor) {
-    // Set a background color (optional, can be styled from theme later)
-    // setAttribute(Qt::WA_StyledBackground, true);
-    // setStyleSheet("background-color: #f0f0f0;"); // Example color
+    // کد اصلاح شده برای سازگاری با Qt5
+    connect(codeEditor->document(), &QTextDocument::blockCountChanged, this, &LineNumberArea::updateLineNumberAreaWidth);
 
-    connect(codeEditor, &QTextEdit::blockCountChanged, this, &LineNumberArea::updateLineNumberAreaWidth);
-
-    // Using contentsChange for updates can be complex.
-    // For scrolling, connecting directly to the scrollbar is often more reliable.
-    // For text changes causing layout shifts (like adding/removing lines not at the end),
-    // blockCountChanged and cursorPositionChanged might be more relevant or simpler to handle.
-    // The update() call in updateLineNumberAreaOnScroll and updateLineNumberAreaWidth
-    // will trigger paintEvent, which recalculates visible lines.
     connect(codeEditor->document()->documentLayout(), &QAbstractTextDocumentLayout::documentSizeChanged, this, [this](){ update(); });
     connect(codeEditor->verticalScrollBar(), &QScrollBar::valueChanged, this, &LineNumberArea::updateLineNumberAreaOnScroll);
-    // Connect to cursorPositionChanged to update if the cursor movement implies a scroll or view change not caught by scrollbar.
     connect(codeEditor, &QTextEdit::cursorPositionChanged, this, &LineNumberArea::updateLineNumberAreaOnScroll);
 
+    updateLineNumberAreaWidth(0);
+}
 
-    updateLineNumberAreaWidth(0); // Initial width calculation
+// Destructor - added as per user's .h file
+LineNumberArea::~LineNumberArea() {
+    // No specific cleanup needed for raw pointers if ownership is handled by Qt's parent-child system
+    // or if codeEditor is owned elsewhere.
 }
 
 QSize LineNumberArea::sizeHint() const {
-    // This cast is necessary because lineNumberAreaWidth is not const.
-    // It's better to make lineNumberAreaWidth const if it doesn't modify member state,
-    // or use a const_cast here if modification is unavoidable but logically const in this context.
-    // For now, let's assume it can be const. If not, this needs adjustment.
     return QSize(const_cast<LineNumberArea*>(this)->lineNumberAreaWidth(), 0);
 }
 
-// Helper function to calculate width
 int LineNumberArea::lineNumberAreaWidth() {
     int digits = 1;
     int max = qMax(1, codeEditor->document()->blockCount());
@@ -43,74 +33,60 @@ int LineNumberArea::lineNumberAreaWidth() {
         max /= 10;
         ++digits;
     }
-    // Adjust space based on font metrics
-    int space = 5 + fontMetrics().horizontalAdvance(QLatin1Char('9')) * digits + 5; // Left padding, digit space, right padding
+    int space = 5 + fontMetrics().horizontalAdvance(QLatin1Char('9')) * digits + 5;
     return space;
 }
 
 void LineNumberArea::updateLineNumberAreaWidth(int /* newBlockCount */) {
     setFixedWidth(lineNumberAreaWidth());
-    update(); // Repaint with new width
+    update();
 }
 
-// This slot is primarily for handling cases where content changes might affect layout
-// without necessarily changing scroll position (e.g., text wrapping changes).
-// For simple line additions/removals, blockCountChanged and scrollbar changes cover most needs.
 void LineNumberArea::updateLineNumberArea(const QRect &/*rect*/, int dy) {
     if (dy != 0) {
-        // This direct scroll might be too simplistic if line heights vary greatly
-        // or if other complex layout changes occur.
-        // The paintEvent is designed to redraw based on visible blocks,
-        // so a simple update() triggered by scrollbar/cursor changes is often enough.
-        // scroll(0, dy); // Potentially problematic, prefer relying on paintEvent triggered by update().
+        // scroll(0, dy);
     }
-    update(); // General repaint for other changes
+    update();
 }
 
 void LineNumberArea::updateLineNumberAreaOnScroll() {
-    update(); // Trigger a repaint, paintEvent will draw the correct numbers.
+    update();
 }
 
 void LineNumberArea::paintEvent(QPaintEvent *event) {
     QPainter painter(this);
-    painter.fillRect(event->rect(), QColor(Qt::lightGray).lighter(110)); // Background color
+    painter.fillRect(event->rect(), QColor(Qt::lightGray).lighter(110));
 
     QAbstractTextDocumentLayout *layout = codeEditor->document()->documentLayout();
-    QPointF editorViewportOffset = codeEditor->contentOffset(); // Physical scroll position in pixels
 
-    // Calculate the first visible block based on the viewport's top edge
+    // کد اصلاح شده برای سازگاری با Qt5
+    QPointF editorViewportOffset(codeEditor->horizontalScrollBar()->value(), codeEditor->verticalScrollBar()->value());
+
     QTextCursor cursor = codeEditor->cursorForPosition(QPoint(0, static_cast<int>(editorViewportOffset.y())));
     int firstVisibleBlockNumber = cursor.blockNumber();
 
     painter.setFont(codeEditor->font());
-    // TODO: Get this color from the theme
     painter.setPen(Qt::darkGray);
 
     QRectF currentBlockRect = layout->blockBoundingRect(codeEditor->document()->findBlockByNumber(firstVisibleBlockNumber));
-
-    // Calculate the initial Y position for drawing the first line number.
-    // This is the top of the first visible block, adjusted by how much it's scrolled off the top of the viewport.
     int currentY = static_cast<int>(currentBlockRect.top() - editorViewportOffset.y() + codeEditor->contentsMargins().top());
 
     int blockCount = codeEditor->document()->blockCount();
     for (int blockNumber = firstVisibleBlockNumber; blockNumber < blockCount; ++blockNumber) {
         if (currentY > event->rect().bottom()) {
-            break; // Stop if we've drawn past the bottom of the paint event's rectangle
+            break;
         }
 
         QTextBlock block = codeEditor->document()->findBlockByNumber(blockNumber);
-        if (!block.isValid() || !block.isVisible()) { // Should always be valid if blockNumber < blockCount
+        if (!block.isValid() || !block.isVisible()) {
             continue;
         }
 
         QString number = QString::number(blockNumber + 1);
-        // Draw text aligned to the right, with some padding.
-        // fontMetrics().height() gives a decent approximation for the line height.
         painter.drawText(0, currentY, width() - 5, fontMetrics().height(), Qt::AlignRight, number);
 
-        // Move to the next block's Y position
         currentBlockRect = layout->blockBoundingRect(block.next());
-        if (!block.next().isValid()) break; // No more blocks
+        if (!block.next().isValid()) break;
         currentY = static_cast<int>(currentBlockRect.top() - editorViewportOffset.y() + codeEditor->contentsMargins().top());
     }
 }


### PR DESCRIPTION
This commit addresses several issues you raised:

1.  I updated `LineNumberArea.h` and `LineNumberArea.cpp` with the code you provided. I ensured that methods intended for use as Qt slots are correctly declared as such in `LineNumberArea.h`.

2.  I enhanced `install.sh`:
    - The script now automatically creates the `build_temp` directory and runs cmake, make, and cpack to build the .deb package if it's missing or if the --rebuild flag is specified.
    - I added error handling and user feedback for the build steps.

Outstanding Issues & Blockers:
- Runtime errors (resource loading, `free(): invalid pointer`) remain unresolved. My attempts to fix these were blocked by a persistent workspace permission issue where root-owned files in `build_temp` (from a `sudo ./install.sh` test) prevented further operations.
- The build process within `install.sh` could not be fully verified for the same reason.
- The updated `LineNumberArea` component is not currently integrated into the `MainWindow` defined in `src/main.cpp`. You will need to perform this integration manually.
- Cleanup of old files in `alte/src/` was also blocked.

Further work is required to resolve the runtime stability and resource loading for installed applications. You will also need to integrate the `LineNumberArea` component into the main application window.