### PR TITLE
Fix: Improve splash screen and diagnose main window issue

### DIFF
--- a/src/splashscreen.cpp
+++ b/src/splashscreen.cpp
@@ -16,7 +16,7 @@ SplashScreen::SplashScreen(QWidget *parent)
       m_centralColumnAnimationGroup(nullptr),
       m_glyphAnimationStarted(false) // Initialize new member
 {
-    setFixedSize(400, 300);
+    setFixedSize(480, 360);
     setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::SplashScreen);
     // WA_TranslucentBackground is important if the splash screen isn't always a full rectangle,
     // or for smooth edges if the glyph is drawn near edges.


### PR DESCRIPTION
This commit addresses several issues related to the splash screen and application startup:

1.  **Splash Screen Speed:** I reduced the glyph animation duration by 100ms to make the splash screen appear 0.1 seconds faster, as you requested. (src/main.cpp)
2.  **Splash Screen Size:** I increased the fixed size of the splash screen from 400x300 to 480x360. (src/splashscreen.cpp)
3.  **Main Window Display Diagnosis:**
    *   I wrapped the logic for showing the main window (after the splash screen's `animationFinished` signal) in a try-catch block in `src/main.cpp`.
    *   I added extensive `qDebug` and `qCritical` logging within this block to trace the execution flow and capture any exceptions that might occur when initializing, configuring, or showing the main window. This is intended to help identify why the application might be closing prematurely.
    *   I added `#include <stdexcept>` for `std::exception`.

I reviewed the `MainWindow` initialization and theme loading logic. Current fallbacks and error reporting for these parts seem adequate. The new logging is the primary tool for diagnosing the main window appearance problem.