### PR TITLE
Fix: Address theme parsing, syntax highlighting, and memory issues

### DIFF
--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -22,6 +22,7 @@ class MainWindow : public QMainWindow {
 public:
     // Updated constructor to accept AlteThemeManager
     MainWindow(AlteThemeManager* p_themeManager, QWidget *parent = nullptr);
+    ~MainWindow(); // Destructor
 
 protected:
     void closeEvent(QCloseEvent *event) override;

--- a/resources/themes/default_dark_neon.json
+++ b/resources/themes/default_dark_neon.json
@@ -78,54 +78,84 @@
     },
     "syntax_highlighting": {
         "python": {
-            "keywords": {
-                "color_ref": "purpleLogic",
-                "bold": true
-            },
-            "booleans": {
-                "color_ref": "creativeFlame",
-                "bold": true
-            },
-            "none_type": {
-                "color_ref": "creativeFlame",
-                "bold": true
-            },
-            "operators": {
-                "color_ref": "lightMist"
-            },
-            "delimiters": {
-                "color_ref": "lightMist"
-            },
-            "function_calls": {
-                "color_ref": "blueSerenity"
-            },
-            "class_names": {
-                "color_ref": "creativeFlame",
-                "bold": true
-            },
-            "self_arg": {
-                "color_ref": "orangeCoral",
-                "italic": true
-            },
-            "numbers": {
-                "color_ref": "creativeFlame"
-            },
-            "docstrings_triple": {
-                "color_ref": "greenWhisper",
-                "italic": true
-            },
-            "strings": {
-                "color_ref": "greenWhisper"
-            },
-            "comments": {
-                "color_ref": "grayEcho",
-                "italic": true,
-                "fontPointSizeOffset": -1
-            },
-            "decorators": {
-                "color_ref": "purpleLogic",
-                "italic": true
-            }
+            "language_name": "Python",
+            "file_extensions": [".py", ".pyw"],
+            "highlighting_rules": [
+                {
+                    "name": "Keywords",
+                    "type": "keywords",
+                    "list": ["def", "class", "if", "else", "elif", "for", "while", "return", "import", "from", "try", "except", "finally", "with", "as", "in", "is", "not", "and", "or", "pass", "break", "continue", "global", "nonlocal", "lambda", "yield", "assert", "del", "raise"],
+                    "color_ref": "purpleLogic", "bold": true
+                },
+                {
+                    "name": "Booleans and None",
+                    "type": "keywords",
+                    "list": ["True", "False", "None"],
+                    "color_ref": "creativeFlame", "bold": true
+                },
+                {
+                    "name": "Line Comment",
+                    "type": "line_comment",
+                    "start_delimiter": "#",
+                    "color_ref": "grayEcho", "italic": true, "fontPointSizeOffset": -1
+                },
+                {
+                    "name": "Triple Quoted String (Double)",
+                    "type": "multi_line_string",
+                    "start_pattern": "\"\"\"",
+                    "end_pattern": "\"\"\"",
+                    "color_ref": "greenWhisper", "italic": true
+                },
+                {
+                    "name": "Triple Quoted String (Single)",
+                    "type": "multi_line_string",
+                    "start_pattern": "'''",
+                    "end_pattern": "'''",
+                    "color_ref": "greenWhisper", "italic": true
+                },
+                {
+                    "name": "String (Double Quote)",
+                    "type": "pattern",
+                    "pattern": "\"[^\"\\\\]*(\\\\.[^\"\\\\]*)*\"",
+                    "color_ref": "greenWhisper"
+                },
+                {
+                    "name": "String (Single Quote)",
+                    "type": "pattern",
+                    "pattern": "'[^'\\\\]*(\\\\.[^'\\\\]*)*'",
+                    "color_ref": "greenWhisper"
+                },
+                {
+                    "name": "Numbers",
+                    "type": "pattern",
+                    "pattern": "\\b([0-9]+\\.?[0-9]*|\\.[0-9]+)([eE][-+]?[0-9]+)?f?\\b|\\b0[xX][0-9a-fA-F]+L?U?\\b|\\b[0-9]+L?U?\\b",
+                    "color_ref": "creativeFlame"
+                },
+                {
+                    "name": "Decorators",
+                    "type": "pattern",
+                    "pattern": "^\\s*@\\w+",
+                    "color_ref": "purpleLogic", "italic": true
+                },
+                {
+                    "name": "Function and Class Names (Definition)",
+                    "type": "pattern",
+                    "pattern": "(?<=(class|def)\\s+)[A-Za-z_][A-Za-z0-9_]+",
+                    "color_ref": "blueSerenity", "bold": true
+                },
+                {
+                    "name": "Function Calls (Heuristic)",
+                    "type": "pattern",
+                    "pattern": "\\b[A-Za-z_][A-Za-z0-9_]*(?=\\()",
+                    "color_ref": "blueSerenity"
+                },
+                {
+                    "name": "Self Argument",
+                    "type": "pattern",
+                    "pattern": "\\bself\\b",
+                    "color_ref": "creativeFlame", "italic": true
+                }
+            ]
         },
         "cpp": {
             "language_name": "C++",
@@ -141,453 +171,178 @@
             ],
             "highlighting_rules": [
                 {
+                    "name": "Keywords",
                     "type": "keywords",
                     "list": [
-                        "alignas",
-                        "alignof",
-                        "and",
-                        "and_eq",
-                        "asm",
-                        "atomic_cancel",
-                        "atomic_commit",
-                        "atomic_noexcept",
-                        "auto",
-                        "bitand",
-                        "bitor",
-                        "bool",
-                        "break",
-                        "case",
-                        "catch",
-                        "char",
-                        "char8_t",
-                        "char16_t",
-                        "char32_t",
-                        "class",
-                        "compl",
-                        "concept",
-                        "const",
-                        "consteval",
-                        "constexpr",
-                        "constinit",
-                        "const_cast",
-                        "continue",
-                        "co_await",
-                        "co_return",
-                        "co_yield",
-                        "decltype",
-                        "default",
-                        "delete",
-                        "do",
-                        "double",
-                        "dynamic_cast",
-                        "else",
-                        "enum",
-                        "explicit",
-                        "export",
-                        "extern",
-                        "false",
-                        "float",
-                        "for",
-                        "friend",
-                        "goto",
-                        "if",
-                        "inline",
-                        "int",
-                        "long",
-                        "mutable",
-                        "namespace",
-                        "new",
-                        "noexcept",
-                        "not",
-                        "not_eq",
-                        "nullptr",
-                        "operator",
-                        "or",
-                        "or_eq",
-                        "private",
-                        "protected",
-                        "public",
-                        "reflexpr",
-                        "register",
-                        "reinterpret_cast",
-                        "requires",
-                        "return",
-                        "short",
-                        "signed",
-                        "sizeof",
-                        "static",
-                        "static_assert",
-                        "static_cast",
-                        "struct",
-                        "switch",
-                        "synchronized",
-                        "template",
-                        "this",
-                        "thread_local",
-                        "throw",
-                        "true",
-                        "try",
-                        "typedef",
-                        "typeid",
-                        "typename",
-                        "union",
-                        "unsigned",
-                        "using",
-                        "virtual",
-                        "void",
-                        "volatile",
-                        "wchar_t",
-                        "while",
-                        "xor",
-                        "xor_eq"
+                        "alignas", "alignof", "and", "and_eq", "asm", "atomic_cancel", "atomic_commit", "atomic_noexcept", "auto", "bitand", "bitor", "bool", "break", "case", "catch", "char", "char8_t", "char16_t", "char32_t", "class", "compl", "concept", "const", "consteval", "constexpr", "constinit", "const_cast", "continue", "co_await", "co_return", "co_yield", "decltype", "default", "delete", "do", "double", "dynamic_cast", "else", "enum", "explicit", "export", "extern", "false", "float", "for", "friend", "goto", "if", "inline", "int", "long", "mutable", "namespace", "new", "noexcept", "not", "not_eq", "nullptr", "operator", "or", "or_eq", "private", "protected", "public", "reflexpr", "register", "reinterpret_cast", "requires", "return", "short", "signed", "sizeof", "static", "static_assert", "static_cast", "struct", "switch", "synchronized", "template", "this", "thread_local", "throw", "true", "try", "typedef", "typeid", "typename", "union", "unsigned", "using", "virtual", "void", "volatile", "wchar_t", "while", "xor", "xor_eq"
                     ],
-                    "style_key": "keyword"
+                    "color_ref": "purpleLogic", "bold": true
                 },
                 {
+                    "name": "Line Comment",
                     "type": "line_comment",
                     "start_delimiter": "//",
-                    "style_key": "comment"
+                    "color_ref": "grayEcho", "italic": true
                 },
                 {
-                    "type": "multi_line_string",
                     "name": "Block Comment",
+                    "type": "multi_line_string",
                     "start_pattern": "/\\*",
                     "end_pattern": "\\*/",
-                    "style_key": "comment"
+                    "color_ref": "grayEcho", "italic": true
                 },
                 {
-                    "type": "multi_line_string",
                     "name": "String",
+                    "type": "multi_line_string",
                     "start_pattern": "\"",
                     "end_pattern": "\"",
-                    "style_key": "string"
+                    "color_ref": "greenWhisper"
                 },
                 {
-                    "type": "pattern",
                     "name": "Character",
+                    "type": "pattern",
                     "pattern": "'([^']|\\\\.)'",
-                    "style_key": "string"
+                    "color_ref": "greenWhisper"
                 },
                 {
-                    "type": "pattern",
                     "name": "Preprocessor",
-                    "pattern": "^\\s*#.*",
-                    "style_key": "preprocessor"
-                },
-                {
                     "type": "pattern",
-                    "name": "Number",
-                    "pattern": "\\\\b([0-9]+\\\\.?[0-9]*|\\\\.[0-9]+)([eE][-+]?[0-9]+)?f?\\\\b|\\\\b0[xX][0-9a-fA-F]+L?U?\\\\b|\\\\b[0-9]+L?U?\\\\b",
-                    "style_key": "number"
+                    "pattern": "^\\s*#.*",
+                    "color_ref": "purpleLogic", "bold": true
                 },
                 {
+                    "name": "Number",
+                    "type": "pattern",
+                    "pattern": "\\b([0-9]+\\.?[0-9]*|\\.[0-9]+)([eE][-+]?[0-9]+)?f?\\b|\\b0[xX][0-9a-fA-F]+L?U?\\b|\\b[0-9]+L?U?\\b",
+                    "color_ref": "creativeFlame"
+                },
+                {
+                    "name": "Common Types and std entities",
                     "type": "keywords",
-                    "name": "Common Types",
                     "list": [
-                        "std::string",
-                        "std::vector",
-                        "std::map",
-                        "std::list",
-                        "std::cout",
-                        "std::cin",
-                        "std::endl",
-                        "size_t",
-                        "int8_t",
-                        "int16_t",
-                        "int32_t",
-                        "int64_t",
-                        "uint8_t",
-                        "uint16_t",
-                        "uint32_t",
-                        "uint64_t"
+                        "std::string", "std::vector", "std::map", "std::list", "std::cout", "std::cin", "std::endl", "size_t", "int8_t", "int16_t", "int32_t", "int64_t", "uint8_t", "uint16_t", "uint32_t", "uint64_t", "QString", "QVector", "QMap", "QList", "cout", "cin", "endl"
                     ],
-                    "style_key": "type_name"
+                    "color_ref": "blueSerenity"
                 }
             ]
         },
         "java": {
             "language_name": "Java",
-            "file_extensions": [
-                ".java"
-            ],
+            "file_extensions": [ ".java" ],
             "highlighting_rules": [
                 {
+                    "name": "Keywords",
                     "type": "keywords",
-                    "list": [
-                        "abstract",
-                        "assert",
-                        "boolean",
-                        "break",
-                        "byte",
-                        "case",
-                        "catch",
-                        "char",
-                        "class",
-                        "const",
-                        "continue",
-                        "default",
-                        "do",
-                        "double",
-                        "else",
-                        "enum",
-                        "extends",
-                        "final",
-                        "finally",
-                        "float",
-                        "for",
-                        "goto",
-                        "if",
-                        "implements",
-                        "import",
-                        "instanceof",
-                        "int",
-                        "interface",
-                        "long",
-                        "native",
-                        "new",
-                        "package",
-                        "private",
-                        "protected",
-                        "public",
-                        "return",
-                        "short",
-                        "static",
-                        "strictfp",
-                        "super",
-                        "switch",
-                        "synchronized",
-                        "this",
-                        "throw",
-                        "throws",
-                        "transient",
-                        "try",
-                        "void",
-                        "volatile",
-                        "while",
-                        "true",
-                        "false",
-                        "null"
-                    ],
-                    "style_key": "keyword"
+                    "list": [ "abstract", "assert", "boolean", "break", "byte", "case", "catch", "char", "class", "const", "continue", "default", "do", "double", "else", "enum", "extends", "final", "finally", "float", "for", "goto", "if", "implements", "import", "instanceof", "int", "interface", "long", "native", "new", "package", "private", "protected", "public", "return", "short", "static", "strictfp", "super", "switch", "synchronized", "this", "throw", "throws", "transient", "try", "void", "volatile", "while", "true", "false", "null" ],
+                    "color_ref": "purpleLogic", "bold": true
                 },
                 {
+                    "name": "Line Comment",
                     "type": "line_comment",
                     "start_delimiter": "//",
-                    "style_key": "comment"
+                    "color_ref": "grayEcho", "italic": true
                 },
                 {
-                    "type": "multi_line_string",
                     "name": "Block Comment",
+                    "type": "multi_line_string",
                     "start_pattern": "/\\*",
                     "end_pattern": "\\*/",
-                    "style_key": "comment"
+                    "color_ref": "grayEcho", "italic": true
                 },
                 {
-                    "type": "multi_line_string",
                     "name": "String",
+                    "type": "multi_line_string",
                     "start_pattern": "\"",
                     "end_pattern": "\"",
-                    "style_key": "string"
+                    "color_ref": "greenWhisper"
                 },
                 {
-                    "type": "pattern",
                     "name": "Character",
+                    "type": "pattern",
                     "pattern": "'([^']|\\\\.)'",
-                    "style_key": "string"
+                    "color_ref": "greenWhisper"
                 },
                 {
-                    "type": "pattern",
                     "name": "Annotations",
-                    "pattern": "@[A-Za-z_][A-Za-z0-9_]*",
-                    "style_key": "preprocessor"
-                },
-                {
                     "type": "pattern",
-                    "name": "Number",
-                    "pattern": "\\\\b([0-9]+\\\\.?[0-9]*|\\\\.[0-9]+)([eE][-+]?[0-9]+)?([fFdDlL])?\\\\b|\\\\b0[xX][0-9a-fA-F]+L?\\\\b|\\\\b[0-9]+L?\\\\b",
-                    "style_key": "number"
+                    "pattern": "@[A-Za-z_][A-Za-z0-9_]*",
+                    "color_ref": "purpleLogic", "italic": true
                 },
                 {
-                    "type": "keywords",
+                    "name": "Number",
+                    "type": "pattern",
+                    "pattern": "\\b([0-9]+\\.?[0-9]*|\\.[0-9]+)([eE][-+]?[0-9]+)?([fFdDlL])?\\b|\\b0[xX][0-9a-fA-F]+L?\\b|\\b[0-9]+L?\\b",
+                    "color_ref": "creativeFlame"
+                },
+                {
                     "name": "Common Types",
-                    "list": [
-                        "String",
-                        "Integer",
-                        "Double",
-                        "Boolean",
-                        "List",
-                        "ArrayList",
-                        "Map",
-                        "HashMap",
-                        "Object",
-                        "Byte",
-                        "Short",
-                        "Long",
-                        "Float",
-                        "Character",
-                        "Void"
-                    ],
-                    "style_key": "type_name"
+                    "type": "keywords",
+                    "list": [ "String", "Integer", "Double", "Boolean", "List", "ArrayList", "Map", "HashMap", "Object", "Byte", "Short", "Long", "Float", "Character", "Void" ],
+                    "color_ref": "blueSerenity"
                 }
             ]
         },
         "javascript": {
             "language_name": "JavaScript",
-            "file_extensions": [
-                ".js",
-                ".mjs",
-                ".cjs"
-            ],
+            "file_extensions": [ ".js", ".mjs", ".cjs" ],
             "highlighting_rules": [
                 {
+                    "name": "Keywords",
                     "type": "keywords",
-                    "list": [
-                        "abstract",
-                        "arguments",
-                        "await",
-                        "boolean",
-                        "break",
-                        "byte",
-                        "case",
-                        "catch",
-                        "char",
-                        "class",
-                        "const",
-                        "continue",
-                        "debugger",
-                        "default",
-                        "delete",
-                        "do",
-                        "double",
-                        "else",
-                        "enum",
-                        "eval",
-                        "export",
-                        "extends",
-                        "false",
-                        "final",
-                        "finally",
-                        "float",
-                        "for",
-                        "function",
-                        "goto",
-                        "if",
-                        "implements",
-                        "import",
-                        "in",
-                        "instanceof",
-                        "int",
-                        "interface",
-                        "let",
-                        "long",
-                        "native",
-                        "new",
-                        "null",
-                        "package",
-                        "private",
-                        "protected",
-                        "public",
-                        "return",
-                        "short",
-                        "static",
-                        "super",
-                        "switch",
-                        "synchronized",
-                        "this",
-                        "throw",
-                        "throws",
-                        "transient",
-                        "true",
-                        "try",
-                        "typeof",
-                        "var",
-                        "void",
-                        "volatile",
-                        "while",
-                        "with",
-                        "yield",
-                        "async",
-                        "of",
-                        "get",
-                        "set"
-                    ],
-                    "style_key": "keyword"
+                    "list": [ "abstract", "arguments", "await", "boolean", "break", "byte", "case", "catch", "char", "class", "const", "continue", "debugger", "default", "delete", "do", "double", "else", "enum", "eval", "export", "extends", "false", "final", "finally", "float", "for", "function", "goto", "if", "implements", "import", "in", "instanceof", "int", "interface", "let", "long", "native", "new", "null", "package", "private", "protected", "public", "return", "short", "static", "super", "switch", "synchronized", "this", "throw", "throws", "transient", "true", "try", "typeof", "var", "void", "volatile", "while", "with", "yield", "async", "of", "get", "set" ],
+                    "color_ref": "purpleLogic", "bold": true
                 },
                 {
+                    "name": "Line Comment",
                     "type": "line_comment",
                     "start_delimiter": "//",
-                    "style_key": "comment"
+                    "color_ref": "grayEcho", "italic": true
                 },
                 {
-                    "type": "multi_line_string",
                     "name": "Block Comment",
+                    "type": "multi_line_string",
                     "start_pattern": "/\\*",
                     "end_pattern": "\\*/",
-                    "style_key": "comment"
+                    "color_ref": "grayEcho", "italic": true
                 },
                 {
-                    "type": "multi_line_string",
                     "name": "Double Quoted String",
+                    "type": "multi_line_string",
                     "start_pattern": "\"",
                     "end_pattern": "\"",
-                    "style_key": "string"
+                    "color_ref": "greenWhisper"
                 },
                 {
-                    "type": "multi_line_string",
                     "name": "Single Quoted String",
+                    "type": "multi_line_string",
                     "start_pattern": "'",
                     "end_pattern": "'",
-                    "style_key": "string"
+                    "color_ref": "greenWhisper"
                 },
                 {
-                    "type": "multi_line_string",
                     "name": "Template Literal",
+                    "type": "multi_line_string",
                     "start_pattern": "`",
                     "end_pattern": "`",
-                    "style_key": "string"
+                    "color_ref": "greenWhisper"
                 },
                 {
-                    "type": "pattern",
                     "name": "Regular Expression",
-                    "pattern": "/[^/\\n\\\\]*(?:\\\\[^\\n]|[^/\\n\\\\])*/[gimyus]*",
-                    "style_key": "preprocessor"
-                },
-                {
                     "type": "pattern",
-                    "name": "Number",
-                    "pattern": "\\\\b([0-9]+\\\\.?[0-9]*|\\\\.[0-9]+)([eE][-+]?[0-9]+)?\\\\b|\\\\b0[xX][0-9a-fA-F]+\\\\b|\\\\b0[bB][01]+\\\\b|\\\\b0[oO][0-7]+\\\\b|\\\\b[0-9]+\\\\b",
-                    "style_key": "number"
+                    "pattern": "/[^/\\n\\\\]*(?:\\\\[^\\n]|[^/\\n\\\\])*/[gimyus]*",
+                    "color_ref": "purpleLogic"
                 },
                 {
-                    "type": "keywords",
+                    "name": "Number",
+                    "type": "pattern",
+                    "pattern": "\\b([0-9]+\\.?[0-9]*|\\.[0-9]+)([eE][-+]?[0-9]+)?\\b|\\b0[xX][0-9a-fA-F]+\\b|\\b0[bB][01]+\\b|\\b0[oO][0-7]+\\b|\\b[0-9]+\\b",
+                    "color_ref": "creativeFlame"
+                },
+                {
                     "name": "Common Objects/Functions",
-                    "list": [
-                        "console",
-                        "log",
-                        "Math",
-                        "JSON",
-                        "Promise",
-                        "Array",
-                        "Object",
-                        "String",
-                        "Number",
-                        "Boolean",
-                        "Function",
-                        "Symbol",
-                        "Date",
-                        "RegExp",
-                        "Error",
-                        "Map",
-                        "Set",
-                        "WeakMap",
-                        "WeakSet",
-                        "document",
-                        "window",
-                        "require",
-                        "module",
-                        "exports"
-                    ],
-                    "style_key": "type_name"
+                    "type": "keywords",
+                    "list": [ "console", "log", "Math", "JSON", "Promise", "Array", "Object", "String", "Number", "Boolean", "Function", "Symbol", "Date", "RegExp", "Error", "Map", "Set", "WeakMap", "WeakSet", "document", "window", "require", "module", "exports" ],
+                    "color_ref": "blueSerenity"
                 }
             ]
         }

--- a/src/AlteSyntaxHighlighter.cpp
+++ b/src/AlteSyntaxHighlighter.cpp
@@ -34,12 +34,12 @@ QTextCharFormat SyntaxHighlighter::createFormatFromRule(const QJsonObject& ruleD
                                                       const QFont& defaultFont,
                                                       AlteThemeManager* themeManager) {
     QTextCharFormat format;
-    QString colorName = ruleDetails.value("color").toString();
-    if (!colorName.isEmpty()) {
-        QColor color = themeManager->getColor(colorName); // getColor can lookup from "colors" or parse hex
-        if (!color.isValid()) { // Fallback if color name is not in theme's "colors" and not a valid hex
-             qWarning() << "SyntaxHighlighter: Color name/hex '" << colorName << "' is invalid or not found in theme colors. Using default text color.";
-             color = themeManager->getColor("text", Qt::black);
+    QString colorNameRef = ruleDetails.value("color_ref").toString(); // Changed from "color"
+    if (!colorNameRef.isEmpty()) {
+        QColor color = themeManager->getColor(colorNameRef); // Use color_ref
+        if (!color.isValid()) { // Fallback if color name is not in theme's "colors"
+             qWarning() << "SyntaxHighlighter: Color reference '" << colorNameRef << "' is invalid or not found in theme colors. Using default text color.";
+             color = themeManager->getColor("text", Qt::black); // Default to theme's text color
         }
         format.setForeground(color);
     }
@@ -91,43 +91,73 @@ void SyntaxHighlighter::loadRulesForLanguage(const QString& languageName, AlteTh
     // Passing an empty QJsonObject for now.
     QJsonObject dummyColors;
 
-    for (const QString& ruleKey : langRules.keys()) {
-        QJsonObject ruleDef = langRules.value(ruleKey).toObject();
+    // In the new JSON structure, langRules is an object like:
+    // { "language_name": "Python", "file_extensions": [".py"], "highlighting_rules": [ {rule1}, {rule2} ] }
+    // We need to iterate over the "highlighting_rules" array.
+
+    if (!langRules.contains("highlighting_rules") || !langRules.value("highlighting_rules").isArray()) {
+        qWarning() << "SyntaxHighlighter: 'highlighting_rules' array not found or not an array for language" << languageName;
+        return;
+    }
+    QJsonArray rulesArray = langRules.value("highlighting_rules").toArray();
+
+    for (const QJsonValue& ruleValue : rulesArray) {
+        QJsonObject ruleDef = ruleValue.toObject();
+        QString ruleName = ruleDef.value("name").toString("Unnamed Rule"); // For logging
+
         HighlightingRule baseRuleSetup;
         baseRuleSetup.format = createFormatFromRule(ruleDef, dummyColors, documentFont, themeManager);
-        baseRuleSetup.isBlockRule = false; // Default to not a block rule
+        baseRuleSetup.isBlockRule = false; // Default
 
         QString ruleType = ruleDef.value("type").toString();
 
-        if (ruleType == "keywords" && ruleDef.contains("list")) {
+        if (ruleType.isEmpty()) {
+            qWarning() << "SyntaxHighlighter: Rule" << ruleName << "is missing 'type' field. Def:" << ruleDef;
+            continue;
+        }
+
+        if (ruleType == "keywords") {
+            if (!ruleDef.contains("list")) {
+                qWarning() << "SyntaxHighlighter: 'keywords' rule" << ruleName << "is missing 'list' field. Def:" << ruleDef;
+                continue;
+            }
             QJsonArray patternsArray = ruleDef.value("list").toArray();
             for (const QJsonValue& val : patternsArray) {
-                HighlightingRule specificRule = baseRuleSetup; // Copy format
-                // For keywords, typically want whole word match
-                // Case sensitivity of QRegularExpression is on by default.
-                // Add \b for word boundaries.
+                HighlightingRule specificRule = baseRuleSetup;
                 QString patternString = "\\b" + QRegularExpression::escape(val.toString()) + "\\b";
                 specificRule.pattern = QRegularExpression(patternString);
                 if (specificRule.pattern.isValid()) {
                     m_highlightingRules.append(specificRule);
                 } else {
-                    qWarning() << "SyntaxHighlighter: Invalid regex from keyword in list" << val.toString() << "for rule" << ruleKey;
+                    qWarning() << "SyntaxHighlighter: Invalid regex from keyword in list" << val.toString() << "for rule" << ruleName;
                 }
             }
-        } else if (ruleType == "line_comment" && ruleDef.contains("start_delimiter")) {
-            HighlightingRule specificRule = baseRuleSetup; // Copy format
+        } else if (ruleType == "line_comment") {
+            if (!ruleDef.contains("start_delimiter")) {
+                qWarning() << "SyntaxHighlighter: 'line_comment' rule" << ruleName << "is missing 'start_delimiter' field. Def:" << ruleDef;
+                continue;
+            }
+            HighlightingRule specificRule = baseRuleSetup;
             QString delimiter = ruleDef.value("start_delimiter").toString();
             if (!delimiter.isEmpty()) {
                 specificRule.pattern = QRegularExpression(QRegularExpression::escape(delimiter) + ".*");
                 if (specificRule.pattern.isValid()) {
                     m_highlightingRules.append(specificRule);
                 } else {
-                    qWarning() << "SyntaxHighlighter: Invalid regex from line_comment rule" << ruleKey << "for delimiter" << delimiter;
+                    qWarning() << "SyntaxHighlighter: Invalid regex from line_comment rule" << ruleName << "for delimiter" << delimiter;
                 }
             } else {
-                qWarning() << "SyntaxHighlighter: Empty delimiter for line_comment rule" << ruleKey;
+                qWarning() << "SyntaxHighlighter: Empty delimiter for line_comment rule" << ruleName;
             }
-        } else if (ruleType == "multi_line_string" || ruleDef.value("block").toBool(false)) {
+        } else if (ruleType == "multi_line_string") {
+            if (!ruleDef.contains("start_pattern")) {
+                qWarning() << "SyntaxHighlighter: 'multi_line_string' rule" << ruleName << "is missing 'start_pattern' field. Def:" << ruleDef;
+                continue;
+            }
+            if (!ruleDef.contains("end_pattern")) {
+                qWarning() << "SyntaxHighlighter: 'multi_line_string' rule" << ruleName << "is missing 'end_pattern' field. Def:" << ruleDef;
+                continue;
+            }
             HighlightingRule blockRule = baseRuleSetup;
             blockRule.isBlockRule = true;
             blockRule.pattern = QRegularExpression(ruleDef.value("start_pattern").toString());
@@ -135,21 +165,35 @@ void SyntaxHighlighter::loadRulesForLanguage(const QString& languageName, AlteTh
             if (blockRule.pattern.isValid() && blockRule.endPattern.isValid()) {
                 m_highlightingRules.append(blockRule);
             } else {
-                qWarning() << "SyntaxHighlighter: Invalid regex for block rule" << ruleKey
+                qWarning() << "SyntaxHighlighter: Invalid regex for 'multi_line_string' rule" << ruleName
                            << ": Start:" << ruleDef.value("start_pattern").toString()
                            << "End:" << ruleDef.value("end_pattern").toString();
             }
-        } else if (ruleDef.contains("pattern")) { // Generic single pattern rule (e.g., "number")
+        } else if (ruleType == "pattern") {
+            if (!ruleDef.contains("pattern")) {
+                qWarning() << "SyntaxHighlighter: 'pattern' rule" << ruleName << "is missing 'pattern' field. Def:" << ruleDef;
+                continue;
+            }
             HighlightingRule singlePatternRule = baseRuleSetup;
-            singlePatternRule.pattern = QRegularExpression(ruleDef.value("pattern").toString());
+            QString patternStr = ruleDef.value("pattern").toString();
+            if (patternStr.isEmpty()){
+                 qWarning() << "SyntaxHighlighter: Empty pattern string for 'pattern' rule" << ruleName;
+                 continue;
+            }
+            singlePatternRule.pattern = QRegularExpression(patternStr);
             if (singlePatternRule.pattern.isValid()) {
                 m_highlightingRules.append(singlePatternRule);
             } else {
-                qWarning() << "SyntaxHighlighter: Invalid regex pattern for rule" << ruleKey << ":" << ruleDef.value("pattern").toString();
+                qWarning() << "SyntaxHighlighter: Invalid regex for 'pattern' rule" << ruleName << ":" << patternStr;
             }
-        } else if (ruleDef.contains("patterns")) { // Legacy: list of literal string patterns (e.g., old keywords format)
+        } else if (ruleDef.contains("patterns")) { // Legacy path, if still needed
             // This can be kept for backward compatibility or removed if all JSONs are updated.
             // For now, let's assume it's similar to "keywords" with "list" but uses "patterns" key.
+            qWarning() << "SyntaxHighlighter: Rule" << ruleName << "uses legacy 'patterns' key. Consider updating to 'list' under 'keywords' type.";
+            if (!ruleDef.contains("patterns")) { // Should not happen if previous 'contains' is true
+                 qWarning() << "SyntaxHighlighter: 'patterns' rule" << ruleName << "is missing 'patterns' field. Def:" << ruleDef;
+                 continue;
+            }
             QJsonArray patternsArray = ruleDef.value("patterns").toArray();
             for (const QJsonValue& val : patternsArray) {
                 HighlightingRule specificRule = baseRuleSetup; // Copy format
@@ -158,24 +202,15 @@ void SyntaxHighlighter::loadRulesForLanguage(const QString& languageName, AlteTh
                 if (specificRule.pattern.isValid()) {
                     m_highlightingRules.append(specificRule);
                 } else {
-                    qWarning() << "SyntaxHighlighter: Invalid regex from legacy 'patterns' list" << val.toString() << "for rule" << ruleKey;
+                    qWarning() << "SyntaxHighlighter: Invalid regex from legacy 'patterns' list" << val.toString() << "for rule" << ruleName;
                 }
             }
-        } else if (ruleDef.value("block").toBool(false) && !ruleDef.contains("start_pattern") && !ruleDef.contains("end_pattern")) {
-            // This case might indicate a rule that was intended to be a block but is missing patterns.
-            // Or it's a type not yet handled.
-             qWarning() << "SyntaxHighlighter: Rule" << ruleKey << "marked as block but missing start/end patterns and not a known type. Def:" << ruleDef;
-        }
-         else {
-            // Only warn if the rule wasn't processed by any of the above conditions.
-            // A rule might be validly empty if it only defines a style to be inherited, though that's not current design.
-            bool isProcessed = (ruleType == "keywords" && ruleDef.contains("list")) ||
-                               (ruleType == "line_comment" && ruleDef.contains("start_delimiter")) ||
-                               (ruleType == "multi_line_string" || ruleDef.value("block").toBool(false)) ||
-                               ruleDef.contains("pattern") ||
-                               ruleDef.contains("patterns");
-            if (!isProcessed && !ruleKey.startsWith("_comment")) { // Don't warn for meta-comment keys in JSON
-                 qWarning() << "SyntaxHighlighter: Rule" << ruleKey << "not processed or understood. Type:" << ruleType << "Def:" << ruleDef;
+        } else {
+            // Rule type not recognized or other issue.
+            // The ruleDef.value("block").toBool(false) was for a flatter structure.
+            // Now, "multi_line_string" is the explicit type for blocks.
+            if (!ruleName.startsWith("_comment_")) { // Don't warn for meta-comment keys in JSON
+                 qWarning() << "SyntaxHighlighter: Rule" << ruleName << "has unknown type'" << ruleType << "' or is malformed. Def:" << ruleDef;
             }
         }
     }

--- a/src/AlteThemeManager.cpp
+++ b/src/AlteThemeManager.cpp
@@ -212,14 +212,13 @@ QString AlteThemeManager::generateGlobalStyleSheet() const {
 
         QString processedStyleValue = originalStyleValue;
         for (auto it = colors.constBegin(); it != colors.constEnd(); ++it) {
-            QString placeholder = QString("%%%%%1%%%%").arg(it.key()); // Current: e.g., %%%%cyberPulse%%%%
-            QString correctPlaceholder = QString("%%%1%%").arg(it.key()); // Corrected: e.g., %%cyberPulse%%
-            if (originalStyleValue.contains(correctPlaceholder)) { // Log only if placeholder is relevant
-                fprintf(stderr, "[generateGlobalStyleSheet]     Replacing placeholder: %s with color: %s (fprintf).\n", correctPlaceholder.toUtf8().constData(), it.value().toString().toUtf8().constData());
+            QString placeholderToReplace = QString("%%%1%%").arg(it.key()); // Format: %%colorName%%
+            if (originalStyleValue.contains(placeholderToReplace)) { // Log only if placeholder is relevant for debugging
+                fprintf(stderr, "[generateGlobalStyleSheet]     Attempting to replace placeholder: %s with color: %s (fprintf).\n", placeholderToReplace.toUtf8().constData(), it.value().toString().toUtf8().constData());
                 fflush(stderr);
-                qDebug().noquote() << "    Replacing placeholder:" << correctPlaceholder << "with color:" << it.value().toString();
+                qDebug().noquote() << "    Attempting to replace placeholder:" << placeholderToReplace << "with color:" << it.value().toString();
             }
-            processedStyleValue.replace(correctPlaceholder, it.value().toString());
+            processedStyleValue.replace(placeholderToReplace, it.value().toString());
         }
         fprintf(stderr, "[generateGlobalStyleSheet]   Processed styleValue: %s (fprintf).\n", processedStyleValue.toUtf8().constData());
         fflush(stderr);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -56,6 +56,14 @@ MainWindow::MainWindow(AlteThemeManager* p_themeManager, QWidget *parent)
     // textEdit->document()->setModified(false); // Set in newFile
 }
 
+// Destructor Implementation
+MainWindow::~MainWindow() {
+    delete highlighter; // Delete the highlighter instance
+    // m_focusTimer is parented to this, will be deleted by Qt.
+    // textEdit is parented to this, will be deleted by Qt.
+    // All QAction members are parented to this, will be deleted by Qt.
+}
+
 // closeEvent Implementation
 void MainWindow::closeEvent(QCloseEvent *event) {
     if (maybeSave()) {


### PR DESCRIPTION
This commit incorporates several fixes to address runtime errors, including potential causes of a "double free or corruption" crash, stylesheet parsing failures, and incorrect syntax highlighting rule processing.

Key changes:

1.  **ThemeManager Stylesheet Generation:**
    - I corrected placeholder replacement logic in `AlteThemeManager::generateGlobalStyleSheet` to ensure `%%colorName%%` placeholders are properly substituted. This resolves the "Could not parse application stylesheet" error.

2.  **SyntaxHighlighter Rule Processing:**
    - I modified `SyntaxHighlighter::createFormatFromRule` to correctly use `"color_ref"` (instead of `"color"`) from the theme JSON when looking up color names.
    - I restructured the Python syntax highlighting rules within `resources/themes/default_dark_neon.json`. The rules are now defined as an array of objects, each with explicit types (e.g., "keywords", "pattern", "line_comment") and associated data (patterns, lists), making it consistent with other language definitions (C++, Java).
    - I updated `SyntaxHighlighter::loadRulesForLanguage` to parse this new array-based structure for highlighting rules and improved its diagnostic messages for malformed rules. This should resolve the "Rule not processed or understood" errors for Python.

3.  **Memory Management:**
    - I added a destructor to `MainWindow` to explicitly `delete` the `SyntaxHighlighter` instance (`highlighter`). This fixes a memory leak.

4.  **MainWindow Refactoring (from previous plan):**
    - I consolidated the `MainWindow` class definition into `include/MainWindow.h` and `src/MainWindow.cpp`, removing the conflicting inline definition in `src/main.cpp`. `CMakeLists.txt` was updated accordingly.

These changes aim to improve application stability and correctness. I was not able to directly verify the "double free or corruption" fix due to limitations preventing build and run tests, but the implemented fixes address the most likely causes identified from logs and code analysis.