### PR TITLE
Fix: Prevent double free of SyntaxHighlighter

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -58,7 +58,13 @@ MainWindow::MainWindow(AlteThemeManager* p_themeManager, QWidget *parent)
 
 // Destructor Implementation
 MainWindow::~MainWindow() {
-    delete highlighter; // Delete the highlighter instance
+    // delete highlighter; // Removed: highlighter is a child of textEdit->document()
+    // highlighter is a child of textEdit->document() due to the
+    // QSyntaxHighlighter(QTextDocument *parent) constructor.
+    // Qt's parent-child mechanism will handle its deletion when the
+    // document (and subsequently textEdit via its own parentage to MainWindow) is destroyed.
+    // Explicitly deleting it here would likely cause a double free.
+
     // m_focusTimer is parented to this, will be deleted by Qt.
     // textEdit is parented to this, will be deleted by Qt.
     // All QAction members are parented to this, will be deleted by Qt.


### PR DESCRIPTION
Addresses the "double free or corruption" error by removing the explicit `delete highlighter;` from `MainWindow::~MainWindow()`.

The `SyntaxHighlighter` instance (`highlighter`) is constructed with `textEdit->document()` as its parent argument. According to Qt's object model, this makes the highlighter a child of the QTextDocument. When the `MainWindow` is destroyed, its child `textEdit` is also destroyed. The destruction of `textEdit` will lead to the destruction of its `QTextDocument`, which in turn will delete all of its children, including the `highlighter` instance.

The previous explicit `delete highlighter;` in `MainWindow`'s destructor was therefore redundant and caused a double free when Qt's parent-child mechanism also attempted to delete the object.

This change relies on Qt's standard memory management to correctly clean up the `SyntaxHighlighter` instance.