### PR TITLE
Refactor: Add diagnostics and verify parsing logic for themes and syntax

### DIFF
--- a/src/AlteSyntaxHighlighter.cpp
+++ b/src/AlteSyntaxHighlighter.cpp
@@ -71,6 +71,7 @@ QTextCharFormat SyntaxHighlighter::createFormatFromRule(const QJsonObject& ruleD
 }
 
 void SyntaxHighlighter::loadRulesForLanguage(const QString& languageName, AlteThemeManager *themeManager) {
+    qDebug() << ">>> loadRulesForLanguage V3 executing <<<";
     qDebug() << "SyntaxHighlighter::loadRulesForLanguage - Loading rules for language:" << languageName;
     m_highlightingRules.clear();
     QJsonObject langRules = themeManager->getSyntaxRulesForLanguage(languageName);

--- a/src/AlteThemeManager.cpp
+++ b/src/AlteThemeManager.cpp
@@ -184,87 +184,29 @@ QString AlteThemeManager::getStyleSheet(const QString& widgetName) const {
 }
 
 QString AlteThemeManager::generateGlobalStyleSheet() const {
-    fprintf(stderr, "[generateGlobalStyleSheet] Entered function (fprintf).\n");
-    fflush(stderr); // Ensure it's flushed
+    qDebug() << ">>> generateGlobalStyleSheet V3 executing <<<";
 
-    qDebug() << "[generateGlobalStyleSheet] Entered function (qDebug).";
-    qDebug() << "[generateGlobalStyleSheet] Number of entries in 'styles' map:" << styles.size();
+    QStringList globalStylesList;
+    // const QJsonObject styles = this->styles; // 'styles' is a member
+    // const QJsonObject colors = this->colors; // 'colors' is a member
 
-    QStringList globalStylesList; // Renamed to avoid confusion with the 'styles' member
     if (styles.isEmpty()) {
-        fprintf(stderr, "[generateGlobalStyleSheet] 'styles' map is empty (fprintf).\n");
-        fflush(stderr);
         qWarning() << "No styles found in theme JSON's 'styles' section to generate global stylesheet.";
     }
-    fprintf(stderr, "[generateGlobalStyleSheet] Starting generation of global stylesheet entries loop (fprintf).\n");
-    fflush(stderr);
-    qDebug() << "Starting generation of global stylesheet entries loop (qDebug)...";
 
     for (const QString& widgetName : styles.keys()) {
-        fprintf(stderr, "[generateGlobalStyleSheet] Processing widgetName: %s (fprintf).\n", widgetName.toUtf8().constData());
-        fflush(stderr);
-        qDebug().noquote() << "Processing widgetName:" << widgetName;
-
         QString originalStyleValue = styles.value(widgetName).toString();
-        fprintf(stderr, "[generateGlobalStyleSheet]   Original styleValue: %s (fprintf).\n", originalStyleValue.toUtf8().constData());
-        fflush(stderr);
-        qDebug().noquote() << "  Original styleValue:" << originalStyleValue;
-
         QString processedStyleValue = originalStyleValue;
         for (auto it = colors.constBegin(); it != colors.constEnd(); ++it) {
             QString placeholderToReplace = QString("%%%1%%").arg(it.key());
             QString colorValue = it.value().toString();
-
-            fprintf(stderr, "[generateGlobalStyleSheet]     Looping for color key: '%s', placeholder: '%s', value: '%s' (fprintf).\n",
-                    it.key().toUtf8().constData(),
-                    placeholderToReplace.toUtf8().constData(),
-                    colorValue.toUtf8().constData());
-            fflush(stderr);
-            qDebug().noquote() << "    Looping for color key:" << it.key()
-                               << ", placeholder:" << placeholderToReplace
-                               << ", value:" << colorValue;
-
-            fprintf(stderr, "[generateGlobalStyleSheet]     processedStyleValue BEFORE replace for '%s': '%s' (fprintf).\n",
-                    placeholderToReplace.toUtf8().constData(),
-                    processedStyleValue.toUtf8().constData());
-            fflush(stderr);
-            qDebug().noquote() << "    processedStyleValue BEFORE replace for" << placeholderToReplace << ":" << processedStyleValue;
-
-            // Perform the replacement
             processedStyleValue.replace(placeholderToReplace, colorValue);
-
-            fprintf(stderr, "[generateGlobalStyleSheet]     processedStyleValue AFTER replace for '%s': '%s' (fprintf).\n",
-                    placeholderToReplace.toUtf8().constData(),
-                    processedStyleValue.toUtf8().constData());
-            fflush(stderr);
-            qDebug().noquote() << "    processedStyleValue AFTER replace for" << placeholderToReplace << ":" << processedStyleValue;
         }
-        fprintf(stderr, "[generateGlobalStyleSheet]   Processed styleValue: %s (fprintf).\n", processedStyleValue.toUtf8().constData());
-        fflush(stderr);
-        qDebug().noquote() << "  Processed styleValue:" << processedStyleValue;
-
         QString styleEntry = QString("%1 { %2 }").arg(widgetName, processedStyleValue);
-        fprintf(stderr, "[generateGlobalStyleSheet]   Generated styleEntry: %s (fprintf).\n", styleEntry.toUtf8().constData());
-        fflush(stderr);
-        qDebug().noquote() << "  Generated styleEntry:" << styleEntry;
         globalStylesList.append(styleEntry);
     }
 
-    fprintf(stderr, "[generateGlobalStyleSheet] Joining QStringList (fprintf).\n");
-    fflush(stderr);
     QString finalStyleSheet = globalStylesList.join("\n");
-
-    fprintf(stderr, "[generateGlobalStyleSheet] Generated global stylesheet with color replacement. Length: %lld (fprintf).\n", static_cast<long long>(finalStyleSheet.length()));
-    fflush(stderr);
-    qDebug() << "Generated global stylesheet with color replacement. Length:" << finalStyleSheet.length();
-
-    if (finalStyleSheet.length() < 3000) { // Also print final stylesheet if short
-        fprintf(stderr, "[generateGlobalStyleSheet] Final Global Stylesheet Content (fprintf):\n%s\n", finalStyleSheet.toUtf8().constData());
-        fflush(stderr);
-        qDebug().noquote() << "Final Global Stylesheet Content (qDebug):\n" << finalStyleSheet;
-    }
-    fprintf(stderr, "[generateGlobalStyleSheet] Returning final stylesheet (fprintf).\n");
-    fflush(stderr);
     return finalStyleSheet;
 }
 


### PR DESCRIPTION
This commit introduces specific changes to aid in diagnosing ongoing issues with stylesheet generation and syntax highlighting rule processing. The core logic for these sections has also been re-verified and set to a known state.

1.  **AlteThemeManager (`AlteThemeManager.cpp`):**
    *   In `generateGlobalStyleSheet`:
        *   I added a unique diagnostic message:
          `>>> generateGlobalStyleSheet V3 executing <<<`
          at the beginning of the method.
        *   I removed all other `fprintf` and `qDebug` general diagnostic
          messages from this method to provide a cleaner output focused
          on the new unique message.
        *   The color placeholder replacement logic (finding `%%colorName%%`
          and replacing it with its hex value) has been confirmed to be in
          the intended state.

2.  **SyntaxHighlighter (`AlteSyntaxHighlighter.cpp`):**
    *   In `loadRulesForLanguage`:
        *   I added a unique diagnostic message:
          `>>> loadRulesForLanguage V3 executing <<<`
          at the beginning of the method.
        *   I retained existing `qDebug` messages that log the `languageName`
          and the content of the `langRules` JSON object received from the
          theme manager, as this provides essential context.
        *   I verified that the logic correctly targets and iterates over the
          `highlighting_rules` array within the language's JSON definition,
          rather than iterating over metadata keys. Essential warnings for
          malformed rules remain.

I verified these changes in the development environment, confirming that they were applied correctly. The new unique log messages are critical for determining if these specific versions of the functions are being executed in your environment, which will help distinguish between code logic errors and potential build/environment discrepancies.