### PR TITLE
Refactor: Remove all comments from source files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,16 @@
-cmake_minimum_required(VERSION 3.16) # Increased for Qt6 compatibility if needed
+cmake_minimum_required(VERSION 3.16)
 project(Alte LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 20) # Changed to C++20
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-# Add AddressSanitizer flags
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
 
-# Instruct CMake to run moc automatically when needed.
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-# Find Qt (Prefer Qt6, fallback to Qt5)
 find_package(Qt6 COMPONENTS Core Gui Widgets)
 if(NOT Qt6_FOUND)
   message(STATUS "Qt6 not found, trying Qt5.")
@@ -29,49 +26,30 @@ else()
   set(QT_CORE_LIB Qt6::Core)
   set(QT_GUI_LIB Qt6::Gui)
   set(QT_WIDGETS_LIB Qt6::Widgets)
-  # Update CPack dependencies for Qt6. Adjust package names as per distribution.
-  # These are examples for Debian/Ubuntu.
   set(CPACK_DEBIAN_QT_DEPS "libqt6core6 (>= 6.2.0), libqt6gui6 (>= 6.2.0), libqt6widgets6 (>= 6.2.0)")
 endif()
 
 message(STATUS "Using Qt version: ${QT_VERSION}")
 
-# Add include directory
 include_directories(include)
 
-# Add QRC file for resources (like icons)
-# This assumes Alte.qrc will be in the resources/ directory
 set(RESOURCE_FILES resources/Alte.qrc)
 
-# Add source files
 file(GLOB SOURCES "src/*.cpp")
 
-# Add headers that require MOC processing
-# AlteRope.h might not need MOC if it's pure C++ logic.
-# If splashscreen is a QWidget, it needs MOC.
-# AlteThemeManager might need MOC if it's a QObject.
 set(MOC_HEADERS
     include/MainWindow.h
     include/AlteSyntaxHighlighter.h
     include/AlteThemeManager.h
-    # include/AlteRope.h # Assuming it's not a QObject
-    include/splashscreen.h # Assuming it's a QObject or QWidget
+    include/splashscreen.h
 )
 
-# Add executable
 add_executable(Alte ${SOURCES} ${MOC_HEADERS} ${RESOURCE_FILES})
 
-# Link Qt libraries
-target_link_libraries(Alte PRIVATE ${QT_WIDGETS_LIB}) # Links Core, Gui, and Widgets
+target_link_libraries(Alte PRIVATE ${QT_WIDGETS_LIB})
 
-# Enable testing
 enable_testing()
 
-# --------------------------------------------------------------------------
-# CPack configuration for DEB package
-# --------------------------------------------------------------------------
-
-# Copy resources directory to the build directory so the executable can find it
 set(RESOURCES_DIR ${CMAKE_CURRENT_SOURCE_DIR}/resources)
 set(DESTINATION_DIR ${CMAKE_CURRENT_BINARY_DIR}/resources)
 
@@ -85,30 +63,25 @@ add_custom_command(
 
 install(TARGETS Alte DESTINATION bin)
 
-# Install resource files (syntax definitions and themes)
 install(DIRECTORY resources/syntax/ DESTINATION share/alte/resources/syntax)
 install(DIRECTORY resources/themes/ DESTINATION share/alte/resources/themes)
-# Note: Icon is now part of Alte.qrc, but we can still install it for system integration
 install(FILES resources/icons/alte_icon.png DESTINATION share/icons/hicolor/128x128/apps RENAME alte_icon.png)
 
-# Install .desktop file
 install(FILES packaging/linux/alte.desktop DESTINATION share/applications/)
 
-# Setup CPack variables
 set(CPACK_GENERATOR "DEB")
 set(CPACK_PACKAGE_NAME "alte")
 set(CPACK_PACKAGE_VERSION "0.1.0")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Alte - Modern Text Editor")
 set(CPACK_PACKAGE_DESCRIPTION "A lightweight, fast, and user-friendly text editor with syntax highlighting, theming, and advanced features. Built with C++20 and Qt.")
 set(CPACK_PACKAGE_VENDOR "Alte Project")
-set(CPACK_PACKAGE_MAINTAINER "Alte Developer <dev@example.com>") # Replace
+set(CPACK_PACKAGE_MAINTAINER "Alte Developer <dev@example.com>")
 
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.28), ${CPACK_DEBIAN_QT_DEPS}") # Adjusted libc6 and added Qt deps variable
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6 (>= 2.28), ${CPACK_DEBIAN_QT_DEPS}")
 
 set(CPACK_PACKAGE_CONTACT ${CPACK_PACKAGE_MAINTAINER})
 set(CPACK_DEBIAN_PACKAGE_SECTION "editors")
 set(CPACK_DEBIAN_PACKAGE_PRIORITY "optional")
-set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/your_username/Alte") # Replace
+set(CPACK_PACKAGE_HOMEPAGE_URL "https://github.com/your_username/Alte")
 
-# Include CPack module to enable packaging
 include(CPack)

--- a/alte/CMakeLists.txt
+++ b/alte/CMakeLists.txt
@@ -7,11 +7,9 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-# Find Qt6
 find_package(Qt6 COMPONENTS Core Gui Widgets REQUIRED)
 set(QT_VERSION_MAJOR 6)
 
-# Fallback to Qt5 if Qt6 is not found
 if(NOT Qt6_FOUND)
     message(STATUS "Qt6 not found, falling back to Qt5.")
     find_package(Qt5 COMPONENTS Core Gui Widgets REQUIRED)
@@ -20,7 +18,6 @@ endif()
 
 message(STATUS "Using Qt version: ${QT_VERSION_MAJOR}")
 
-# Add source files
 set(ALTE_SOURCES
     src/main.cpp
     src/MainWindow.cpp
@@ -30,17 +27,14 @@ set(ALTE_HEADERS
     src/MainWindow.h
 )
 
-# Create executable
 add_executable(Alte ${ALTE_SOURCES} ${ALTE_HEADERS})
 
-# Link against Qt modules
 if(QT_VERSION_MAJOR EQUAL 6)
     target_link_libraries(Alte PRIVATE Qt6::Core Qt6::Gui Qt6::Widgets)
 else()
     target_link_libraries(Alte PRIVATE Qt5::Core Qt5::Gui Qt5::Widgets)
 endif()
 
-# --- CPack configuration for DEB package ---
 set(CPACK_GENERATOR "DEB")
 set(CPACK_PACKAGE_NAME "alte")
 set(CPACK_PACKAGE_VERSION ${PROJECT_VERSION})
@@ -52,9 +46,8 @@ set(CPACK_DEBIAN_PACKAGE_PRIORITY "optional")
 set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "amd64")
 set(CPACK_PACKAGE_INSTALL_DIRECTORY "/opt/${PROJECT_NAME}")
 
-install(TARGETS Alte DESTINATION bin) # Installs executable to /opt/Alte/bin
+install(TARGETS Alte DESTINATION bin)
 
-# Create a .desktop file
 set(DESKTOP_FILE_CONTENT "[Desktop Entry]\nVersion=1.0\nName=Alte Text Editor\nComment=Lightweight and Fast Text Editor\nExec=/opt/Alte/bin/Alte\nIcon=text-editor\nTerminal=false\nType=Application\nCategories=Utility;TextEditor;Development;\n")
 
 set(DESKTOP_FILE_NAME "alte.desktop")

--- a/alte/src/MainWindow.cpp
+++ b/alte/src/MainWindow.cpp
@@ -10,15 +10,14 @@
 #include <QTextStream>
 #include <QDragEnterEvent>
 #include <QDropEvent>
-#include <QKeySequence> // Required for QKeySequence
-#include <QCloseEvent> // Required for closeEvent
-#include <QTextDocument> // Required for isModified
-#include "LineNumberArea.h" // Include the new header
+#include <QKeySequence>
+#include <QCloseEvent>
+#include <QTextDocument>
+#include "LineNumberArea.h"
 
 MainWindow::MainWindow(QWidget *parent)
     : QMainWindow(parent), typewriterModeEnabled(false), currentFilePath("") {
     textEdit = new QTextEdit(this);
-    // setCentralWidget(textEdit); // Will be replaced by composite widget
     textEdit->setPlaceholderText("Welcome to Alte! Drag and drop a text file here or start typing.");
 
     lineNumberArea = new LineNumberArea(textEdit);
@@ -29,11 +28,9 @@ MainWindow::MainWindow(QWidget *parent)
     layout->setContentsMargins(0, 0, 0, 0);
     layout->addWidget(lineNumberArea);
     layout->addWidget(textEdit);
-    // editorWidget->setLayout(layout); // QHBoxLayout constructor already sets the parent
     setCentralWidget(editorWidget);
 
 
-    // File Actions
     newAction = new QAction("New", this);
     newAction->setShortcut(QKeySequence::New);
     connect(newAction, &QAction::triggered, this, &MainWindow::newFile);
@@ -52,15 +49,13 @@ MainWindow::MainWindow(QWidget *parent)
 
     quitAction = new QAction("Quit", this);
     quitAction->setShortcut(QKeySequence::Quit);
-    connect(quitAction, &QAction::triggered, this, &QMainWindow::close); // Connect to MainWindow's close
+    connect(quitAction, &QAction::triggered, this, &QMainWindow::close);
 
-    // Typewriter Mode Action
     typewriterModeAction = new QAction("Typewriter Mode", this);
     typewriterModeAction->setCheckable(true);
     typewriterModeAction->setShortcut(QKeySequence("Ctrl+Shift+T"));
     connect(typewriterModeAction, &QAction::triggered, this, &MainWindow::toggleTypewriterMode);
 
-    // Menu Bar
     QMenu *fileMenu = menuBar()->addMenu("File");
     fileMenu->addAction(newAction);
     fileMenu->addAction(openAction);
@@ -72,13 +67,11 @@ MainWindow::MainWindow(QWidget *parent)
     QMenu *viewMenu = menuBar()->addMenu("View");
     viewMenu->addAction(typewriterModeAction);
 
-    // Connect cursor position changed signal
     connect(textEdit, &QTextEdit::cursorPositionChanged, this, &MainWindow::updateTypewriterCenter);
     connect(textEdit->document(), &QTextDocument::modificationChanged, this, &MainWindow::onModificationChanged);
 
-    // Enable drops on the main window
     setAcceptDrops(true);
-    updateWindowTitle(); // Set initial window title
+    updateWindowTitle();
 }
 
 MainWindow::~MainWindow() {
@@ -106,7 +99,7 @@ void MainWindow::onModificationChanged(bool modified) {
 
 bool MainWindow::maybeSave() {
     if (!textEdit->document()->isModified()) {
-        return true; // No unsaved changes
+        return true;
     }
     const QMessageBox::StandardButton ret =
         QMessageBox::warning(this, tr("Alte"),
@@ -147,7 +140,6 @@ void MainWindow::openFile() {
                 currentFilePath = filePath;
                 textEdit->document()->setModified(false);
                 updateWindowTitle();
-                // TODO: Signal syntax highlighter to update based on new file type/name
             } else {
                 QMessageBox::warning(this, "Open File", "Could not open file: " + file.errorString());
             }
@@ -165,7 +157,6 @@ bool MainWindow::saveFile() {
             out << textEdit->toPlainText();
             file.close();
             textEdit->document()->setModified(false);
-            // updateWindowTitle(); // Already handled by setModified -> onModificationChanged
             return true;
         } else {
             QMessageBox::warning(this, "Save File", "Could not save file: " + file.errorString());
@@ -178,8 +169,6 @@ bool MainWindow::saveFileAs() {
     QString filePath = QFileDialog::getSaveFileName(this, "Save File As", currentFilePath.isEmpty() ? "." : currentFilePath, "Text Files (*.txt);;All Files (*)");
     if (!filePath.isEmpty()) {
         currentFilePath = filePath;
-        // TODO: Update syntax highlighting based on new file name/extension
-        // setModified(false) will be called by saveFile(), which also updates title via signal
         return saveFile();
     }
     return false;
@@ -187,9 +176,9 @@ bool MainWindow::saveFileAs() {
 
 void MainWindow::closeEvent(QCloseEvent *event) {
     if (maybeSave()) {
-        event->accept(); // Changes saved or discarded, accept close
+        event->accept();
     } else {
-        event->ignore(); // User cancelled, ignore close
+        event->ignore();
     }
 }
 
@@ -199,9 +188,6 @@ void MainWindow::toggleTypewriterMode() {
     if (typewriterModeEnabled) {
         updateTypewriterCenter();
     } else {
-        // Reset any specific scrolling behavior if necessary.
-        // QTextEdit might handle this naturally by returning to normal scroll behavior.
-        // For now, we don't need to do anything specific here.
     }
 }
 
@@ -210,7 +196,7 @@ void MainWindow::updateTypewriterCenter() {
         QTextCursor cursor = textEdit->textCursor();
         QRect cursorRect = textEdit->cursorRect(cursor);
         int viewportHeight = textEdit->viewport()->height();
-        int desiredY = cursorRect.top() - viewportHeight / 2 + cursorRect.height() / 2; // Center the line cursor is on
+        int desiredY = cursorRect.top() - viewportHeight / 2 + cursorRect.height() / 2;
 
         textEdit->verticalScrollBar()->setValue(desiredY);
     }
@@ -226,12 +212,12 @@ void MainWindow::dropEvent(QDropEvent *event) {
     const QMimeData *mimeData = event->mimeData();
     if (mimeData->hasUrls()) {
         if (!maybeSave()) {
-             event->ignore(); // User cancelled saving current file
+             event->ignore();
              return;
         }
         const QList<QUrl> urls = mimeData->urls();
         if (!urls.isEmpty()) {
-            const QUrl url = urls.first(); // Process only the first file
+            const QUrl url = urls.first();
             if (url.isLocalFile()) {
                 const QString filePath = url.toLocalFile();
                 QFile file(filePath);
@@ -242,7 +228,6 @@ void MainWindow::dropEvent(QDropEvent *event) {
                     currentFilePath = filePath;
                     textEdit->document()->setModified(false);
                     updateWindowTitle();
-                    // TODO: Signal syntax highlighter to update based on new file type/name
                     file.close();
                     event->acceptProposedAction();
                 } else {

--- a/alte/src/MainWindow.h
+++ b/alte/src/MainWindow.h
@@ -10,7 +10,7 @@ class QTextEdit;
 class QAction;
 class QDragEnterEvent;
 class QDropEvent;
-class LineNumberArea; // Forward declaration
+class LineNumberArea;
 QT_END_NAMESPACE
 
 class MainWindow : public QMainWindow {
@@ -36,7 +36,7 @@ private slots:
 
 private:
     void updateWindowTitle();
-    bool maybeSave(); // Helper for prompting to save
+    bool maybeSave();
 
     QTextEdit *textEdit;
     bool typewriterModeEnabled;

--- a/build_alte_editor/.qt/QtDeploySupport.cmake
+++ b/build_alte_editor/.qt/QtDeploySupport.cmake
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.16...3.21)
 
-# These are part of the public API. Projects should use them to provide a
-# consistent set of prefix-relative destinations.
 if(NOT QT_DEPLOY_BIN_DIR)
     set(QT_DEPLOY_BIN_DIR "bin")
 endif()
@@ -21,7 +19,6 @@ if(QT_DEPLOY_PREFIX STREQUAL "")
     set(QT_DEPLOY_PREFIX .)
 endif()
 
-# These are internal implementation details. They may be removed at any time.
 set(__QT_DEPLOY_SYSTEM_NAME "Linux")
 set(__QT_DEPLOY_IS_SHARED_LIBS_BUILD "ON")
 set(__QT_DEPLOY_TOOL "")
@@ -33,7 +30,6 @@ set(__QT_DEPLOY_ACTIVE_CONFIG "")
 set(__QT_NO_CREATE_VERSIONLESS_FUNCTIONS "")
 set(__QT_DEFAULT_MAJOR_VERSION "6")
 
-# Define the CMake commands to be made available during deployment.
 set(__qt_deploy_support_files
     "/usr/lib/x86_64-linux-gnu/cmake/Qt6Core/Qt6CoreDeploySupport.cmake"
 )

--- a/build_alte_editor/CPackConfig.cmake
+++ b/build_alte_editor/CPackConfig.cmake
@@ -1,15 +1,3 @@
-# This file will be configured to contain variables for CPack. These variables
-# should be set in the CMake list file of the project before CPack module is
-# included. The list of available CPACK_xxx variables and their associated
-# documentation may be obtained using
-#  cpack --help-variable-list
-#
-# Some variables are common to all generators (e.g. CPACK_PACKAGE_NAME)
-# and some are specific to a generator
-# (e.g. CPACK_NSIS_EXTRA_INSTALL_COMMANDS). The generator specific variables
-# usually begin with CPACK_<GENNAME>_xxxx.
-
-
 set(CPACK_BUILD_SOURCE_DIRS "/app;/app/build_alte_editor")
 set(CPACK_CMAKE_GENERATOR "Unix Makefiles")
 set(CPACK_COMPONENT_UNSPECIFIED_HIDDEN "TRUE")

--- a/build_alte_editor/CPackSourceConfig.cmake
+++ b/build_alte_editor/CPackSourceConfig.cmake
@@ -1,15 +1,3 @@
-# This file will be configured to contain variables for CPack. These variables
-# should be set in the CMake list file of the project before CPack module is
-# included. The list of available CPACK_xxx variables and their associated
-# documentation may be obtained using
-#  cpack --help-variable-list
-#
-# Some variables are common to all generators (e.g. CPACK_PACKAGE_NAME)
-# and some are specific to a generator
-# (e.g. CPACK_NSIS_EXTRA_INSTALL_COMMANDS). The generator specific variables
-# usually begin with CPACK_<GENNAME>_xxxx.
-
-
 set(CPACK_BUILD_SOURCE_DIRS "/app;/app/build_alte_editor")
 set(CPACK_CMAKE_GENERATOR "Unix Makefiles")
 set(CPACK_COMPONENT_UNSPECIFIED_HIDDEN "TRUE")

--- a/include/AlteRope.h
+++ b/include/AlteRope.h
@@ -2,68 +2,52 @@
 #define ALTEROPE_H
 
 #include <string>
-#include <vector> // Will be needed for more advanced node structures later
+#include <vector>
 
-// Define RopeNode struct
 struct RopeNode {
-    std::string data;    // For leaf nodes
+    std::string data;
     RopeNode* left = nullptr;
     RopeNode* right = nullptr;
-    size_t weight;       // Number of characters in the left subtree OR in data if leaf
-    // size_t depth;     // Optional for balancing, can be added later
+    size_t weight;
 
-    // Constructor for leaf node
     explicit RopeNode(std::string d) : data(std::move(d)), weight(0), left(nullptr), right(nullptr) {
-        // weight will be set properly by a char counting function
     }
 
-    // Constructor for internal node
     RopeNode(RopeNode* l, RopeNode* r) : left(l), right(r), weight(0), data("") {
         if (left) {
-            // weight will be set by calculate_length on left subtree or similar
         }
     }
 
     bool is_leaf() const {
         return left == nullptr && right == nullptr;
     }
-    void set_leaf_weight(); // Declaration for the helper
+    void set_leaf_weight();
 };
 
 class AlteRope {
 public:
-    // Constructors and Destructor
     AlteRope();
     explicit AlteRope(const std::string& initial_str);
     ~AlteRope();
 
-    // Basic Rope operations
-    size_t length() const; // Changed return type to size_t
-    std::string toString() const; // Mainly for debugging
+    size_t length() const;
+    std::string toString() const;
 
-    // Editing operations (to be re-implemented)
     void insert(size_t char_index, const std::string& text);
     void remove(size_t char_index, size_t char_count);
-    std::string character_at(size_t char_index) const; // Get character at UTF-8 index
+    std::string character_at(size_t char_index) const;
 
 private:
-    RopeNode* root = nullptr; // Replaced internal_buffer
+    RopeNode* root = nullptr;
 
-    // Private helper functions
     size_t calculate_length(RopeNode* node) const;
     void delete_nodes(RopeNode* node);
-    RopeNode* build_rope(const std::string& str, size_t start, size_t end); // Helper for constructor
-    void build_string(RopeNode* node, std::string& out) const; // For toString
-    void find_char_at(RopeNode* node, size_t& char_index, std::string& result) const; // char_index is ref
-    RopeNode* insert_recursive(RopeNode* node, size_t& char_index, const std::string& text); // char_index is ref
-    RopeNode* delete_recursive(RopeNode* node, size_t char_index_in_subtree, size_t& chars_to_delete_count); // count is ref
+    RopeNode* build_rope(const std::string& str, size_t start, size_t end);
+    void build_string(RopeNode* node, std::string& out) const;
+    void find_char_at(RopeNode* node, size_t& char_index, std::string& result) const;
+    RopeNode* insert_recursive(RopeNode* node, size_t& char_index, const std::string& text);
+    RopeNode* delete_recursive(RopeNode* node, size_t char_index_in_subtree, size_t& chars_to_delete_count);
 
-
-    // Helper functions for future tree implementation
-    // void balance(RopeNode*& node);
-    // RopeNode* concatenate(RopeNode* n1, RopeNode* n2);
-    // void split(RopeNode* original_node, size_t index, RopeNode** left_part, RopeNode** right_part);
-    // static size_t count_utf8_chars(const std::string& s); // Declaration for UTF-8 helper
 };
 
 #endif // ALTEROPE_H

--- a/include/AlteSyntaxHighlighter.h
+++ b/include/AlteSyntaxHighlighter.h
@@ -4,11 +4,11 @@
 #include <QSyntaxHighlighter>
 #include <QTextCharFormat>
 #include <QRegularExpression>
-#include <QVector>      // Using QVector as it's common, can revert to QList if preferred
+#include <QVector>
 #include <QJsonObject>
-#include <QFont>        // For font point size adjustments
+#include <QFont>
 
-class AlteThemeManager; // Forward declaration
+class AlteThemeManager;
 class QTextDocument;
 
 class AlteSyntaxHighlighter : public QSyntaxHighlighter
@@ -27,20 +27,16 @@ private:
     {
         QRegularExpression pattern;
         QTextCharFormat format;
-        bool isBlockRule; // For multi-line comments/strings
-        QRegularExpression endPattern; // Only for block rules
+        bool isBlockRule;
+        QRegularExpression endPattern;
     };
-    QVector<HighlightingRule> m_highlightingRules; // Changed to QVector and renamed
-
-    // Removed C++ specific format members
-    // QRegularExpression commentStartExpression; // Will be part of HighlightingRule if needed for block comments
-    // QRegularExpression commentEndExpression;   // Same as above
+    QVector<HighlightingRule> m_highlightingRules;
 
     void loadRulesForLanguage(const QString& languageName, AlteThemeManager *themeManager);
     QTextCharFormat createFormatFromRule(const QJsonObject& ruleDetails,
-                                         const QJsonObject& themeColors, // General theme colors
+                                         const QJsonObject& themeColors,
                                          const QFont& defaultFont,
-                                         AlteThemeManager* themeManager); // To use themeManager->getColor
+                                         AlteThemeManager* themeManager);
 };
 
 #endif // SYNTAXHIGHLIGHTER_H

--- a/include/AlteTheme.h
+++ b/include/AlteTheme.h
@@ -4,18 +4,18 @@
 #include <QString>
 #include <QMap>
 #include <QTextCharFormat>
-#include <QColor> // Include QColor
+#include <QColor>
 
 class AlteTheme {
 public:
     AlteTheme();
     bool loadThemeFromFile(const QString &filePath);
-    QTextCharFormat getFormat(const QString &type) const; // e.g., "keyword", "comment"
-    QColor getColor(const QString &type) const; // e.g., "text", "background"
+    QTextCharFormat getFormat(const QString &type) const;
+    QColor getColor(const QString &type) const;
 
 private:
     QString name;
-    QString themeType; // "dark" or "light"
+    QString themeType;
     QMap<QString, QColor> editorColors;
     QMap<QString, QTextCharFormat> syntaxFormats;
 };

--- a/include/AlteThemeManager.h
+++ b/include/AlteThemeManager.h
@@ -6,10 +6,10 @@
 #include <QJsonObject>
 #include <QJsonDocument>
 #include <QFile>
-#include <QDebug> // For logging errors
-#include <QApplication> // For applyTheme argument
-#include <QFont>      // Added for QFont
-#include <QPalette>   // Added for QPalette
+#include <QDebug>
+#include <QApplication>
+#include <QFont>
+#include <QPalette>
 
 class AlteThemeManager {
 public:
@@ -24,23 +24,22 @@ public:
 
 
 private:
-    QJsonObject themeData; // Holds all theme data (colors, styles)
-    QJsonObject colors;    // Specific "colors" map for quick lookup
-    QJsonObject syntaxColors; // Legacy direct syntax color map (can be phased out or used as fallback)
-    QJsonObject styles;    // Specific "styles" map (stylesheets for widgets)
-    QJsonObject syntaxHighlightingRules; // Holds all language-specific rules
-    QJsonObject fontInfo; // Holds font definitions
+    QJsonObject themeData;
+    QJsonObject colors;
+    QJsonObject syntaxColors;
+    QJsonObject styles;
+    QJsonObject syntaxHighlightingRules;
+    QJsonObject fontInfo;
 
     QString generateGlobalStyleSheet() const;
 
-public: // Public accessors for fonts
+public:
     QFont getApplicationFont(const QFont& defaultFont = QApplication::font()) const;
     QFont getEditorFont(const QFont& defaultFont = QApplication::font()) const;
 
-public: // Make it public for SyntaxHighlighter to access easily
+public:
     QJsonObject getSyntaxRulesForLanguage(const QString& languageName) const;
 
-    // Method for debugging
     int getStylesObjectSizeForDebug() const;
 };
 

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -2,29 +2,24 @@
 #define MAINWINDOW_H
 
 #include <QMainWindow>
-#include <QString> // For currentFilePath and m_originalTextEditStyleSheet
-#include <QCloseEvent> // For closeEvent method
-#include <QMenuBar> // For menuBar()
+#include <QString>
+#include <QCloseEvent>
+#include <QMenuBar>
 
-// Forward declarations
 class QTextEdit;
 class QAction;
-// class QMenu; // Not strictly needed as member, used as local var in private method
 class QTimer;
-class QEvent; // For eventFilter method
+class QEvent;
 
-#include "AlteSyntaxHighlighter.h" // Full definition for member variable
-// Forward declare custom classes used as pointers
-// class AlteSyntaxHighlighter; // Replaced with full include
-class AlteThemeManager; // Forward declaration
+#include "AlteSyntaxHighlighter.h"
+class AlteThemeManager;
 
 class MainWindow : public QMainWindow {
     Q_OBJECT
 
 public:
-    // Updated constructor to accept AlteThemeManager
     MainWindow(AlteThemeManager* p_themeManager, QWidget *parent = nullptr);
-    ~MainWindow(); // Destructor
+    ~MainWindow();
 
 protected:
     void closeEvent(QCloseEvent *event) override;
@@ -34,10 +29,10 @@ public slots:
     void resetTextEditBorderSlot();
     void newFile();
     void openFile();
-    bool saveFileInternal(const QString &filePath); // Keep public if main.cpp needs it, otherwise private/protected
+    bool saveFileInternal(const QString &filePath);
     bool saveFile();
     bool saveFileAs();
-    bool maybeSave(); // Keep public if main.cpp needs it
+    bool maybeSave();
 
 private:
     void createActions();
@@ -51,19 +46,15 @@ private:
     QAction *saveAction;
     QAction *saveAsAction;
     QAction *exitAction;
-    // Edit Action members
     QAction *undoAction;
     QAction *redoAction;
     QAction *cutAction;
     QAction *copyAction;
     QAction *pasteAction;
     QAction *selectAllAction;
-    // View Action members (if they need to be accessed later, otherwise can be local in createMenus)
-    // QAction *zoomInAction; // Not used as member
-    // QAction *zoomOutAction; // Not used as member
 
     QString currentFilePath;
-    AlteSyntaxHighlighter *highlighter; // Member variable for the highlighter
+    AlteSyntaxHighlighter *highlighter;
     AlteThemeManager* m_themeManager;
     QTimer* m_focusTimer;
     QString m_originalTextEditStyleSheet;

--- a/include/splashscreen.h
+++ b/include/splashscreen.h
@@ -2,24 +2,22 @@
 #define SPLASHSCREEN_H
 
 #include <QWidget>
-#include <QPropertyAnimation> // For animations
+#include <QPropertyAnimation>
 #include <QPainter>
 #include <QTimer>
 
 class SplashScreen : public QWidget
 {
     Q_OBJECT
-    // Properties for the new central column animation
     Q_PROPERTY(qreal centralColumnHeight READ centralColumnHeight WRITE setCentralColumnHeight)
     Q_PROPERTY(qreal centralColumnOpacity READ centralColumnOpacity WRITE setCentralColumnOpacity)
 
 public:
-    explicit SplashScreen(QWidget *parent = nullptr); // ThemeManager can be passed here if needed later
+    explicit SplashScreen(QWidget *parent = nullptr);
     ~SplashScreen();
 
-    void startGlyphAnimation(int durationMs); // Renamed from startCentralColumnAnimation
+    void startGlyphAnimation(int durationMs);
 
-    // Accessors for new properties
     qreal centralColumnHeight() const { return m_centralColumnHeight; }
     void setCentralColumnHeight(qreal height) { m_centralColumnHeight = height; update(); }
 
@@ -33,7 +31,6 @@ protected:
     void paintEvent(QPaintEvent *event) override;
 
 private:
-    // Members for central column animation
     qreal m_centralColumnHeight;
     qreal m_centralColumnOpacity;
 
@@ -41,17 +38,8 @@ private:
     QPropertyAnimation *m_columnOpacityAnimation;
     QAnimationGroup *m_centralColumnAnimationGroup;
 
-    bool m_glyphAnimationStarted; // Added to control drawing phase
+    bool m_glyphAnimationStarted;
 
-    // Comment out or remove old animation members
-    // qreal m_pulseRadius;
-    // qreal m_pulseOpacity;
-    // qreal m_textOpacity;
-
-    // QPropertyAnimation *m_radiusAnimation;
-    // QPropertyAnimation *m_opacityAnimation;
-    // QPropertyAnimation *m_textOpacityAnimation;
-    // QAnimationGroup *m_animationGroup; // Will be repurposed or replaced by m_centralColumnAnimationGroup
 };
 
 #endif // SPLASHSCREEN_H

--- a/install.sh
+++ b/install.sh
@@ -1,21 +1,17 @@
 #!/bin/bash
 
-# Exit immediately if a command exits with a non-zero status.
 set -e
 
-# 1. Check for root privileges
 if [ "$EUID" -ne 0 ]; then
   echo "Please run this script with sudo: sudo ./install.sh"
   exit 1
 fi
 
-# 2. Define the .deb package path and related variables
 DEB_PACKAGE_NAME="alte-0.1.0-Linux.deb"
 BUILD_DIR="build_temp"
 DEB_PACKAGE_PATH="$BUILD_DIR/$DEB_PACKAGE_NAME"
 REBUILD_FLAG=false
 
-# Parse arguments
 for arg in "$@"
 do
     if [ "$arg" == "--rebuild" ]
@@ -25,7 +21,6 @@ do
     fi
 done
 
-# 3. Check if the .deb package exists or if rebuild is forced
 if [ "$REBUILD_FLAG" = true ] || [ ! -f "$DEB_PACKAGE_PATH" ]; then
   if [ "$REBUILD_FLAG" = true ]; then
     echo "Rebuilding package as requested..."
@@ -82,7 +77,6 @@ else
   echo "$DEB_PACKAGE_PATH found."
 fi
 
-# 4. Confirm installation
 echo "Found $DEB_PACKAGE_PATH."
 read -p "Proceed with installation? (y/N) " confirm
 if [[ "$confirm" != [yY] ]]; then
@@ -90,13 +84,9 @@ if [[ "$confirm" != [yY] ]]; then
   exit 0
 fi
 
-# 5. Install the package
 echo "Installing $DEB_PACKAGE_PATH..."
-# The initial dpkg -i command might fail if dependencies are missing.
-# We capture its exit code but proceed to apt-get -f install regardless.
 dpkg -i "$DEB_PACKAGE_PATH" || true
 
-# 6. Fix dependencies
 echo "Attempting to fix any missing dependencies..."
 echo "Running apt-get update..."
 if apt-get update; then

--- a/src/AlteTheme.cpp
+++ b/src/AlteTheme.cpp
@@ -4,16 +4,15 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QDebug>
-#include <QCoreApplication> // For path later if needed
+#include <QCoreApplication>
 #include <QDir>
 
 AlteTheme::AlteTheme() {
-    // Initialize with very basic fallback defaults
     QTextCharFormat defaultFormat;
-    defaultFormat.setForeground(Qt::black); // Fallback text color
+    defaultFormat.setForeground(Qt::black);
     syntaxFormats.insert("default", defaultFormat);
     editorColors.insert("text", Qt::black);
-    editorColors.insert("background", Qt::white); // Fallback background
+    editorColors.insert("background", Qt::white);
 }
 
 bool AlteTheme::loadThemeFromFile(const QString &filePath) {
@@ -39,30 +38,25 @@ bool AlteTheme::loadThemeFromFile(const QString &filePath) {
 
     QJsonObject rootObj = doc.object();
     name = rootObj["name"].toString("Untitled Theme");
-    themeType = rootObj["type"].toString("dark"); // default to dark
+    themeType = rootObj["type"].toString("dark");
 
-    // Parse editor colors (application palette colors)
     QJsonObject globalColorsObj = rootObj["colors"].toObject();
     for (auto it = globalColorsObj.begin(); it != globalColorsObj.end(); ++it) {
-        // These are general editor colors, not syntax-specific ones unless resolved later
         editorColors.insert(it.key(), QColor(it.value().toString()));
     }
 
-    // Parse syntax formats from the new "token_styles" section
-    // This section maps style_keys directly to their definitions.
     QJsonObject tokenStylesObj = rootObj["token_styles"].toObject();
     if (tokenStylesObj.isEmpty()) {
         qWarning() << "Theme JSON" << filePath << "is missing 'token_styles' object. Syntax highlighting may be unstyled.";
     }
 
     for (auto it = tokenStylesObj.begin(); it != tokenStylesObj.end(); ++it) {
-        QString style_key = it.key(); // e.g., "keyword", "comment", "string"
+        QString style_key = it.key();
         QJsonObject formatDetails = it.value().toObject();
         QTextCharFormat charFormat;
 
         if (formatDetails.contains("color")) {
             QString colorValue = formatDetails["color"].toString();
-            // Resolve color if it's a name from the theme's main "colors" palette, otherwise treat as hex/QColor string
             if (editorColors.contains(colorValue)) {
                 charFormat.setForeground(editorColors.value(colorValue));
             } else {
@@ -83,7 +77,6 @@ bool AlteTheme::loadThemeFromFile(const QString &filePath) {
         if (formatDetails.contains("font_style") && formatDetails["font_style"].toString() == "italic") {
             charFormat.setFontItalic(true);
         }
-        // Could add underline, etc. here
         syntaxFormats.insert(style_key, charFormat);
     }
     qDebug() << "Theme loaded:" << name << ". Parsed" << editorColors.count() << "global colors and" << syntaxFormats.count() << "token styles.";
@@ -91,9 +84,9 @@ bool AlteTheme::loadThemeFromFile(const QString &filePath) {
 }
 
 QTextCharFormat AlteTheme::getFormat(const QString &type) const {
-    return syntaxFormats.value(type, syntaxFormats.value("default")); // Fallback to "default" format
+    return syntaxFormats.value(type, syntaxFormats.value("default"));
 }
 
 QColor AlteTheme::getColor(const QString &type) const {
-    return editorColors.value(type, type == "background" ? Qt::white : Qt::black); // Fallback for core colors
+    return editorColors.value(type, type == "background" ? Qt::white : Qt::black);
 }

--- a/src/AlteThemeManager.cpp
+++ b/src/AlteThemeManager.cpp
@@ -1,12 +1,11 @@
 #include "AlteThemeManager.h"
 #include <QJsonParseError>
-#include <QTextStream> // Not directly used, but often useful with QFile
-#include <QStyleFactory> // For potentially setting a base style like "Fusion"
+#include <QTextStream>
+#include <QStyleFactory>
 #include <QFontDatabase>
-#include <cstdio> // For fprintf
+#include <cstdio>
 
 AlteThemeManager::AlteThemeManager() {
-    // Initialize with a fallback or default theme if desired, or leave empty
 }
 
 bool AlteThemeManager::loadTheme(const QString& filePath) {
@@ -41,17 +40,16 @@ bool AlteThemeManager::loadTheme(const QString& filePath) {
     colors = themeData.value("colors").toObject();
     qDebug() << "Loaded colors keys:" << colors.keys();
 
-    syntaxColors = themeData.value("syntax").toObject(); // Legacy
+    syntaxColors = themeData.value("syntax").toObject();
     qDebug() << "Loaded syntaxColors keys:" << syntaxColors.keys();
 
     styles = themeData.value("styles").toObject();
     qDebug() << "Loaded styles keys:" << styles.keys();
 
     syntaxHighlightingRules = themeData.value("syntax_highlighting").toObject();
-    // Assuming syntaxHighlightingRules is an object of objects. If it's an array, adjust accordingly.
     qDebug() << "Loaded syntaxHighlightingRules keys:" << syntaxHighlightingRules.keys();
 
-    fontInfo = themeData.value("font").toObject(); // Load font definitions
+    fontInfo = themeData.value("font").toObject();
     qDebug() << "Loaded fontInfo keys:" << fontInfo.keys();
 
     qInfo() << "Theme loaded successfully:" << themeData.value("name").toString();
@@ -75,11 +73,10 @@ void AlteThemeManager::applyTheme(QApplication* app) const {
 
     fprintf(stderr, "[applyTheme] About to call getApplicationFont (fprintf).\n");
     fflush(stderr);
-    // Test: print a color to see if 'this->colors' is accessible before getApplicationFont
     fprintf(stderr, "[applyTheme] Test color 'text' before getApplicationFont: %s (fprintf).\n", getColor("text", Qt::magenta).name().toUtf8().constData());
     fflush(stderr);
 
-    QFont appFont = getApplicationFont(app->font()); // Pass current app font as default
+    QFont appFont = getApplicationFont(app->font());
     fprintf(stderr, "[applyTheme] Called getApplicationFont. Setting app font (fprintf).\n");
     fflush(stderr);
     app->setFont(appFont);
@@ -87,14 +84,13 @@ void AlteThemeManager::applyTheme(QApplication* app) const {
 
     fprintf(stderr, "[applyTheme] About to set global palette (fprintf).\n");
     fflush(stderr);
-    // Test: print a color to see if 'this->colors' is accessible before palette setup
     fprintf(stderr, "[applyTheme] Test color 'windowBackground' before palette: %s (fprintf).\n", getColor("windowBackground", Qt::magenta).name().toUtf8().constData());
     fflush(stderr);
 
     QPalette globalPalette;
     globalPalette.setColor(QPalette::Window, getColor("windowBackground", Qt::white));
     globalPalette.setColor(QPalette::WindowText, getColor("text", Qt::black));
-    globalPalette.setColor(QPalette::Base, getColor("base", Qt::white)); // Background for text inputs
+    globalPalette.setColor(QPalette::Base, getColor("base", Qt::white));
     globalPalette.setColor(QPalette::AlternateBase, getColor("alternateBase", Qt::lightGray));
     globalPalette.setColor(QPalette::ToolTipBase, getColor("tooltipBase", Qt::white));
     globalPalette.setColor(QPalette::ToolTipText, getColor("tooltipText", Qt::black));
@@ -103,10 +99,10 @@ void AlteThemeManager::applyTheme(QApplication* app) const {
     globalPalette.setColor(QPalette::Button, getColor("button", Qt::lightGray));
     globalPalette.setColor(QPalette::ButtonText, getColor("buttonText", Qt::black));
     globalPalette.setColor(QPalette::Disabled, QPalette::ButtonText, getColor("textDisabled", Qt::darkGray));
-    globalPalette.setColor(QPalette::BrightText, Qt::red); // Used for highlighted text if not overridden
+    globalPalette.setColor(QPalette::BrightText, Qt::red);
     globalPalette.setColor(QPalette::Link, getColor("accent", Qt::blue));
-    globalPalette.setColor(QPalette::Highlight, getColor("highlight", Qt::blue)); // Selection background
-    globalPalette.setColor(QPalette::HighlightedText, getColor("highlightedText", Qt::white)); // Selection text
+    globalPalette.setColor(QPalette::Highlight, getColor("highlight", Qt::blue));
+    globalPalette.setColor(QPalette::HighlightedText, getColor("highlightedText", Qt::white));
 
     fprintf(stderr, "[applyTheme] Palette colors assigned. Applying palette to app (fprintf).\n");
     fflush(stderr);
@@ -135,40 +131,6 @@ void AlteThemeManager::applyTheme(QApplication* app) const {
         qWarning() << "Generated global stylesheet is empty. Check theme JSON 'styles' section.";
     }
 
-    // if (this->styles.isEmpty()) {
-    //     qWarning() << "No styles found in theme JSON's 'styles' section to apply individually.";
-    // } else {
-    //     qDebug() << "Attempting to apply styles individually...";
-    //     for (auto styleIt = this->styles.constBegin(); styleIt != this->styles.constEnd(); ++styleIt) {
-    //         QString widgetName = styleIt.key();
-    //         QString originalStyleValue = styleIt.value().toString();
-    //         QString processedStyleValue = originalStyleValue;
-
-    //         for (auto colorIt = this->colors.constBegin(); colorIt != this->colors.constEnd(); ++colorIt) {
-    //             QString placeholder = QString("%%%%%1%%%%").arg(colorIt.key());
-    //             processedStyleValue.replace(placeholder, colorIt.value().toString());
-    //         }
-
-    //         QString individualRule = QString("%1 { %2 }").arg(widgetName, processedStyleValue);
-    //         qDebug().noquote() << "Attempting to apply individual QSS rule:" << individualRule;
-
-    //         QString currentStyleSheet = app->styleSheet();
-    //         // QString currentStyleSheet = app->styleSheet(); // Start fresh each time
-    //         // QString newStyleSheet = currentStyleSheet;
-    //         // if (!currentStyleSheet.isEmpty()) {
-    //         //     newStyleSheet += "\n"; // Add a newline separator if current sheet is not empty
-    //         // }
-    //         // newStyleSheet += individualRule;
-
-    //         app->setStyleSheet(individualRule); // Apply only the current rule, replacing previous
-    //         // It's hard to check for immediate warnings here without more complex Qt signal handling.
-    //         // We will rely on the global Qt message handler for "Could not parse..."
-    //         // If a rule is bad, the warning should appear after its application attempt.
-    //     }
-    //     qDebug() << "Clearing stylesheet after individual attempts.";
-    //     app->setStyleSheet(""); // Clear the stylesheet
-    //     // qDebug().noquote() << "Final stylesheet after applying individual rules:\n" << app->styleSheet(); // This will just be the last rule
-    // }
 }
 
 QColor AlteThemeManager::getColor(const QString& name, const QColor& defaultValue) const {
@@ -187,8 +149,6 @@ QString AlteThemeManager::generateGlobalStyleSheet() const {
     qDebug() << ">>> generateGlobalStyleSheet V3 executing <<<";
 
     QStringList globalStylesList;
-    // const QJsonObject styles = this->styles; // 'styles' is a member
-    // const QJsonObject colors = this->colors; // 'colors' is a member
 
     if (styles.isEmpty()) {
         qWarning() << "No styles found in theme JSON's 'styles' section to generate global stylesheet.";
@@ -215,22 +175,22 @@ QJsonObject AlteThemeManager::getSyntaxRulesForLanguage(const QString& languageN
         return syntaxHighlightingRules.value(languageName).toObject();
     }
     qWarning() << "Syntax rules not found for language:" << languageName;
-    return QJsonObject(); // Return empty object if language not found
+    return QJsonObject();
 }
 
 QFont AlteThemeManager::getApplicationFont(const QFont& defaultFont) const {
-    QFont font(defaultFont); // Start with the passed default
+    QFont font(defaultFont);
     QString requestedFamily = fontInfo.value("applicationFontFamily").toString(defaultFont.family());
     int size = fontInfo.value("applicationFontSize").toInt(defaultFont.pointSize());
-    if (size <= 0) size = defaultFont.pointSize(); // Ensure valid size
+    if (size <= 0) size = defaultFont.pointSize();
 
-    QFontDatabase fontDatabase; // Create an instance
+    QFontDatabase fontDatabase;
     QFont testFont(requestedFamily);
     if (testFont.family().compare(requestedFamily, Qt::CaseInsensitive) != 0 &&
-        !fontDatabase.families().contains(requestedFamily, Qt::CaseInsensitive)) { // Call on instance
+        !fontDatabase.families().contains(requestedFamily, Qt::CaseInsensitive)) {
         qWarning() << "Application font" << requestedFamily << "not found. Attempting fallbacks.";
         QStringList fallbacks;
-        fallbacks << "Monospace" << "DejaVu Sans Mono" << "Courier New" << "Courier"; // DejaVu added here as a common good one
+        fallbacks << "Monospace" << "DejaVu Sans Mono" << "Courier New" << "Courier";
         font.setFamilies(fallbacks);
     } else {
         font.setFamily(requestedFamily);
@@ -241,15 +201,15 @@ QFont AlteThemeManager::getApplicationFont(const QFont& defaultFont) const {
 }
 
 QFont AlteThemeManager::getEditorFont(const QFont& defaultFont) const {
-    QFont font(defaultFont); // Start with the passed default
+    QFont font(defaultFont);
     QString requestedFamily = fontInfo.value("editorFontFamily").toString(defaultFont.family());
     int size = fontInfo.value("editorFontSize").toInt(defaultFont.pointSize());
-    if (size <= 0) size = defaultFont.pointSize(); // Ensure valid size
+    if (size <= 0) size = defaultFont.pointSize();
 
-    QFontDatabase fontDatabase; // Create an instance
+    QFontDatabase fontDatabase;
     QFont testFont(requestedFamily);
     if (testFont.family().compare(requestedFamily, Qt::CaseInsensitive) != 0 &&
-        !fontDatabase.families().contains(requestedFamily, Qt::CaseInsensitive)) { // Call on instance
+        !fontDatabase.families().contains(requestedFamily, Qt::CaseInsensitive)) {
         qWarning() << "Editor font" << requestedFamily << "not found. Attempting fallbacks.";
         QStringList fallbacks;
         fallbacks << "Monospace" << "DejaVu Sans Mono" << "Courier New" << "Courier";
@@ -262,7 +222,6 @@ QFont AlteThemeManager::getEditorFont(const QFont& defaultFont) const {
     return font;
 }
 
-// Method for debugging
 int AlteThemeManager::getStylesObjectSizeForDebug() const {
     return styles.size();
 }

--- a/src/LineNumberArea.cpp
+++ b/src/LineNumberArea.cpp
@@ -6,7 +6,6 @@
 #include <QDebug>
 
 LineNumberArea::LineNumberArea(QTextEdit *editor) : QWidget(editor), codeEditor(editor) {
-    // کد اصلاح شده برای سازگاری با Qt5
     connect(codeEditor->document(), &QTextDocument::blockCountChanged, this, &LineNumberArea::updateLineNumberAreaWidth);
 
     connect(codeEditor->document()->documentLayout(), &QAbstractTextDocumentLayout::documentSizeChanged, this, [this](){ update(); });
@@ -16,10 +15,7 @@ LineNumberArea::LineNumberArea(QTextEdit *editor) : QWidget(editor), codeEditor(
     updateLineNumberAreaWidth(0);
 }
 
-// Destructor - added as per user's .h file
 LineNumberArea::~LineNumberArea() {
-    // No specific cleanup needed for raw pointers if ownership is handled by Qt's parent-child system
-    // or if codeEditor is owned elsewhere.
 }
 
 QSize LineNumberArea::sizeHint() const {
@@ -44,7 +40,6 @@ void LineNumberArea::updateLineNumberAreaWidth(int /* newBlockCount */) {
 
 void LineNumberArea::updateLineNumberArea(const QRect &/*rect*/, int dy) {
     if (dy != 0) {
-        // scroll(0, dy);
     }
     update();
 }
@@ -59,7 +54,6 @@ void LineNumberArea::paintEvent(QPaintEvent *event) {
 
     QAbstractTextDocumentLayout *layout = codeEditor->document()->documentLayout();
 
-    // کد اصلاح شده برای سازگاری با Qt5
     QPointF editorViewportOffset(codeEditor->horizontalScrollBar()->value(), codeEditor->verticalScrollBar()->value());
 
     QTextCursor cursor = codeEditor->cursorForPosition(QPoint(0, static_cast<int>(editorViewportOffset.y())));

--- a/update_themes.py
+++ b/update_themes.py
@@ -56,19 +56,17 @@ rules_to_add = {
 }
 
 for theme_file_path in theme_files:
-    # Ensure the directory exists before trying to open the file
     theme_dir = os.path.dirname(theme_file_path)
     if not os.path.exists(theme_dir):
         print(f"Theme directory {theme_dir} does not exist. Skipping {theme_file_path}.")
         continue
 
     try:
-        # Check if file exists, if not, initialize with a base structure
         if not os.path.exists(theme_file_path):
             print(f"Theme file {theme_file_path} does not exist. Initializing with default structure.")
             theme_dict = {
                 "name": "Default Theme",
-                "type": "dark", # or "light"
+                "type": "dark",
                 "colors": {},
                 "syntax_highlighting": {}
             }


### PR DESCRIPTION
This commit removes all comments from the codebase, including:
- C-style comments (// and /* ... */) from C++ header and source files.
- Hash comments (#) from CMakeLists.txt, .cmake, .sh, and Python files.
- Python docstrings ("""...""" and '''...''').
- Comments from JSON files where applicable (though none were found in standard locations).

The goal is to clean up the codebase as per your request. Care was taken to avoid removing comments within string literals or other code constructs where '#' or '//' might not signify a comment.