### PR TITLE
feat: Implement advanced shortcut management system

### DIFF
--- a/alte/CMakeLists.txt
+++ b/alte/CMakeLists.txt
@@ -21,10 +21,16 @@ message(STATUS "Using Qt version: ${QT_VERSION_MAJOR}")
 set(ALTE_SOURCES
     src/main.cpp
     src/MainWindow.cpp
+    src/ShortcutManager.cpp
+    src/ShortcutSettingsDialog.cpp
+    src/ScratchpadDialog.cpp
 )
 
 set(ALTE_HEADERS
     src/MainWindow.h
+    src/ShortcutManager.h
+    src/ShortcutSettingsDialog.h
+    src/ScratchpadDialog.h
 )
 
 add_executable(Alte ${ALTE_SOURCES} ${ALTE_HEADERS})

--- a/alte/src/MainWindow.h
+++ b/alte/src/MainWindow.h
@@ -8,6 +8,7 @@
 #include <QMenu>  // Added
 #include "include/AlteSyntaxHighlighter.h" // Adjusted path
 #include "include/AlteThemeManager.h"   // Adjusted path
+#include "ShortcutManager.h" // Added for ShortcutManager
 
 
 QT_BEGIN_NAMESPACE
@@ -17,6 +18,8 @@ class QDragEnterEvent;
 class QDropEvent;
 class LineNumberArea;
 // Forward declare QLabel if QStatusBar is not included, but it's better to include for status bar usage.
+class ShortcutSettingsDialog; // Forward declaration
+class ScratchpadDialog; // Forward declaration
 // QStatusBar is part of QMainWindow, so it's available.
 QT_END_NAMESPACE
 
@@ -43,6 +46,9 @@ private slots:
     void onModificationChanged(bool modified);
     void showLanguageMenu(); // Added
     void setCurrentLanguageFromMenu(QAction* action); // Added
+    void openScratchpad(); // Added
+    void toggleZenMode(); // Added
+    void openShortcutSettingsDialog(); // Added
 
 private:
     void updateWindowTitle();
@@ -59,14 +65,23 @@ private:
     QAction *saveAction;
     QAction *saveAsAction;
     QAction *quitAction;
+    QAction* m_openScratchpadAction; // Added
+    QAction* m_zenModeAction; // Added
+    QAction* m_shortcutSettingsAction; // Added
 
     LineNumberArea *lineNumberArea;
+    QWidget *editorWidget; // Make editorWidget a member to access its layout containing lineNumberArea
 
     // Language and Syntax Highlighting
     AlteThemeManager* m_themeManager; // Assuming MainWindow owns or has access to this
     AlteSyntaxHighlighter* m_syntaxHighlighter; // Manages syntax highlighting for textEdit
     QString m_currentLanguageName;
     QLabel* m_languageStatusLabel; // Added
+    ShortcutManager* m_shortcutManager; // Added
+
+    bool m_isZenModeActive; // Added
+    ScratchpadDialog* m_scratchpadDialog; // Added
+    // No need to store original visibility, QWidget::isHidden() gives current state before change.
 };
 
 #endif // MAINWINDOW_H

--- a/src/ScratchpadDialog.cpp
+++ b/src/ScratchpadDialog.cpp
@@ -1,0 +1,103 @@
+#include "ScratchpadDialog.h"
+#include <QVBoxLayout>
+#include <QFile>
+#include <QTextStream>
+#include <QStandardPaths>
+#include <QDir>
+#include <QDebug>
+#include <QCloseEvent>
+
+ScratchpadDialog::ScratchpadDialog(QWidget *parent)
+    : QDialog(parent) {
+    setupUi();
+    setWindowTitle("Scratchpad");
+    setMinimumSize(300, 400);
+    // Make it modeless but stay on top
+    setModal(false);
+    setWindowFlags(Qt::Window | Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowCloseButtonHint | Qt::WindowStaysOnTopHint);
+
+
+    m_saveDebounceTimer.setInterval(1500); // Save 1.5 seconds after last edit
+    m_saveDebounceTimer.setSingleShot(true);
+    connect(&m_saveDebounceTimer, &QTimer::timeout, this, &ScratchpadDialog::saveContent);
+    connect(m_textEdit, &QTextEdit::textChanged, this, &ScratchpadDialog::onTextChanged);
+
+    // Initial load attempt in constructor or first showEvent
+    // loadContent(); // showEvent is better to ensure parent is set for positioning etc.
+}
+
+ScratchpadDialog::~ScratchpadDialog() {
+    // Ensure content is saved on destruction if pending
+    if (m_saveDebounceTimer.isActive()) {
+        m_saveDebounceTimer.stop();
+        saveContent();
+    }
+}
+
+void ScratchpadDialog::setupUi() {
+    QVBoxLayout* mainLayout = new QVBoxLayout(this);
+    m_textEdit = new QTextEdit(this);
+    m_textEdit->setPlaceholderText("Jot down your notes here...");
+    mainLayout->addWidget(m_textEdit);
+    setLayout(mainLayout);
+}
+
+QString ScratchpadDialog::getScratchpadFilePath() const {
+    QString dataPath = QStandardPaths::writableLocation(QStandardPaths::AppLocalDataLocation);
+    if (dataPath.isEmpty()) {
+        qWarning() << "Scratchpad: Could not determine AppLocalDataLocation. Using current dir.";
+        dataPath = QDir::currentPath(); // Fallback
+    }
+    QDir dataDir(dataPath);
+    if (!dataDir.exists()) {
+        dataDir.mkpath(".");
+    }
+    return dataDir.filePath("alte_scratchpad.txt");
+}
+
+void ScratchpadDialog::loadContent() {
+    QString filePath = getScratchpadFilePath();
+    QFile file(filePath);
+    if (file.exists() && file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        QTextStream in(&file);
+        m_textEdit->setPlainText(in.readAll());
+        file.close();
+        qDebug() << "Scratchpad content loaded from" << filePath;
+    } else {
+        qDebug() << "Scratchpad file not found or could not be opened. Starting fresh.";
+    }
+}
+
+void ScratchpadDialog::saveContent() {
+    QString filePath = getScratchpadFilePath();
+    QFile file(filePath);
+    if (file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        QTextStream out(&file);
+        out << m_textEdit->toPlainText();
+        file.close();
+        qDebug() << "Scratchpad content saved to" << filePath;
+    } else {
+        qWarning() << "Could not save scratchpad content to" << filePath << ":" << file.errorString();
+    }
+}
+
+void ScratchpadDialog::onTextChanged() {
+    m_saveDebounceTimer.start(); // Restart timer on each text change
+}
+
+void ScratchpadDialog::closeEvent(QCloseEvent *event) {
+    if (m_saveDebounceTimer.isActive()) {
+        m_saveDebounceTimer.stop(); // Stop timer
+        saveContent(); // Save immediately
+    }
+    QDialog::closeEvent(event);
+}
+
+void ScratchpadDialog::showEvent(QShowEvent *event) {
+    if (!m_textEdit->document()->isEmpty() && m_textEdit->toPlainText().isEmpty()) {
+        // This check is a bit weak, ideally load only once.
+        // Or, if you want it to refresh every time it's shown (might not be desired)
+    }
+    loadContent(); // Load content when dialog is shown
+    QDialog::showEvent(event);
+}

--- a/src/ScratchpadDialog.h
+++ b/src/ScratchpadDialog.h
@@ -1,0 +1,37 @@
+#ifndef SCRATCHPADDIALOG_H
+#define SCRATCHPADDIALOG_H
+
+#include <QDialog>
+#include <QTextEdit>
+#include <QTimer> // For debouncing save
+
+QT_BEGIN_NAMESPACE
+class QTextEdit;
+class QPushButton;
+QT_END_NAMESPACE
+
+class ScratchpadDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit ScratchpadDialog(QWidget *parent = nullptr);
+    ~ScratchpadDialog();
+
+protected:
+    void closeEvent(QCloseEvent *event) override;
+    void showEvent(QShowEvent *event) override;
+
+private slots:
+    void loadContent();
+    void saveContent();
+    void onTextChanged();
+
+private:
+    void setupUi();
+    QString getScratchpadFilePath() const;
+
+    QTextEdit* m_textEdit;
+    QTimer m_saveDebounceTimer;
+};
+
+#endif // SCRATCHPADDIALOG_H

--- a/src/ShortcutManager.cpp
+++ b/src/ShortcutManager.cpp
@@ -1,0 +1,259 @@
+#include "ShortcutManager.h"
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+#include <QStandardPaths>
+#include <QDir>
+#include <QAction> // Include QAction
+#include <QDebug>  // For logging
+
+ShortcutManager::ShortcutManager(QObject *parent)
+    : QObject(parent), m_configFilePath("shortcuts.json") {
+    initializeDefaultShortcuts();
+    // Attempt to load user-defined shortcuts, potentially overriding defaults
+    // loadShortcuts(); // We might call this explicitly after MainWindow setup
+}
+
+ShortcutManager::~ShortcutManager() {}
+
+void ShortcutManager::initializeDefaultShortcuts() {
+    registerCoreShortcut(CommandId::NEW_FILE, "Ctrl+N", "New File");
+    registerCoreShortcut(CommandId::OPEN_FILE, "Ctrl+O", "Open File");
+    registerCoreShortcut(CommandId::SAVE_FILE, "Ctrl+S", "Save File");
+    registerCoreShortcut(CommandId::SAVE_AS_FILE, "Ctrl+Shift+S", "Save File As");
+    registerCoreShortcut(CommandId::QUIT_APP, "Ctrl+Q", "Quit Application");
+    registerCoreShortcut(CommandId::TOGGLE_TYPEWRITER_MODE, "Ctrl+Shift+T", "Toggle Typewriter Mode");
+    registerCoreShortcut(CommandId::OPEN_SHORTCUT_SETTINGS, "Ctrl+Alt+S", "Open Shortcut Settings");
+    registerCoreShortcut(CommandId::ZEN_MODE, "F11", "Toggle Zen Mode");
+    registerCoreShortcut(CommandId::OPEN_SCRATCHPAD, "Ctrl+Shift+P", "Open Scratchpad");
+
+    qDebug() << "Default shortcuts initialized. Total:" << m_shortcuts.count();
+}
+
+bool ShortcutManager::registerCoreShortcut(CommandId id, const QString& defaultSequence, const QString& description, QAction* action) {
+    return registerNamedShortcut(commandIdToString(id), defaultSequence, description, action);
+}
+
+bool ShortcutManager::registerNamedShortcut(const QString& commandName, const QString& defaultSequence, const QString& description, QAction* action) {
+    if (commandName.isEmpty()) {
+        qWarning() << "ShortcutManager: Cannot register shortcut with empty command name.";
+        return false;
+    }
+    if (m_shortcuts.contains(commandName)) {
+        qWarning() << "ShortcutManager: Command" << commandName << "already registered. Updating description and default sequence.";
+        m_shortcuts[commandName].description = description;
+        m_shortcuts[commandName].defaultSequence = defaultSequence;
+        // If currentSequence was loaded from user config, don't overwrite with default here.
+        // It will be handled by loadShortcuts. If not loaded, it should take default.
+        if (m_shortcuts[commandName].currentSequence.isEmpty() || m_shortcuts[commandName].currentSequence == m_shortcuts[commandName].defaultSequence) {
+             m_shortcuts[commandName].currentSequence = defaultSequence;
+        }
+    } else {
+        m_shortcuts.insert(commandName, ShortcutInfo(commandName, defaultSequence, defaultSequence, description, nullptr));
+        qDebug() << "ShortcutManager: Registered" << commandName << "(" << description << ") with default" << defaultSequence;
+    }
+
+    if (action) {
+        connectToAction(commandName, action);
+    }
+    return true;
+}
+
+void ShortcutManager::connectToAction(const QString& commandName, QAction* action) {
+    if (!action) return;
+
+    if (m_shortcuts.contains(commandName)) {
+        m_shortcuts[commandName].action = action;
+        applyShortcutToAction(commandName, m_shortcuts[commandName].currentSequence);
+        // Connect action's triggered signal if we need to intercept or log,
+        // but typically QAction handles its own triggering.
+    } else {
+        qWarning() << "ShortcutManager: Cannot connect QAction. Command" << commandName << "not registered.";
+    }
+}
+
+void ShortcutManager::applyShortcutToAction(const QString& commandName, const QString& sequenceStr) {
+    if (m_shortcuts.contains(commandName) && m_shortcuts[commandName].action) {
+        QKeySequence keySeq = QKeySequence::fromString(sequenceStr, QKeySequence::PortableText);
+        if (!keySeq.isEmpty() || sequenceStr.isEmpty()) { // Allow empty string to clear shortcut
+            m_shortcuts[commandName].action->setShortcut(keySeq);
+            qDebug() << "Applied shortcut" << keySeq.toString() << "to action for command" << commandName;
+        } else {
+            qWarning() << "ShortcutManager: Could not parse key sequence" << sequenceStr << "for command" << commandName;
+        }
+    }
+}
+
+bool ShortcutManager::updateShortcut(const QString& commandName, const QString& newSequenceStr) {
+    if (m_shortcuts.contains(commandName)) {
+        QKeySequence newKeySeq = QKeySequence::fromString(newSequenceStr, QKeySequence::PortableText);
+        // Allow empty sequence to remove a shortcut
+        if (newKeySeq.isEmpty() && !newSequenceStr.isEmpty()) {
+            qWarning() << "ShortcutManager: Invalid key sequence string provided:" << newSequenceStr;
+            return false;
+        }
+
+        m_shortcuts[commandName].currentSequence = newSequenceStr; // Store as string
+        if (m_shortcuts[commandName].action) {
+            m_shortcuts[commandName].action->setShortcut(newKeySeq);
+        }
+        emit shortcutChanged(commandName, newKeySeq);
+        qDebug() << "ShortcutManager: Updated shortcut for" << commandName << "to" << newSequenceStr;
+        // Consider saving all shortcuts here or provide a separate save mechanism
+        saveShortcuts(m_configFilePath);
+        return true;
+    }
+    qWarning() << "ShortcutManager: Cannot update. Command" << commandName << "not found.";
+    return false;
+}
+
+QKeySequence ShortcutManager::getShortcut(const QString& commandName) const {
+    if (m_shortcuts.contains(commandName)) {
+        return QKeySequence::fromString(m_shortcuts[commandName].currentSequence, QKeySequence::PortableText);
+    }
+    return QKeySequence(); // Return empty sequence if not found
+}
+
+QString ShortcutManager::getShortcutString(const QString& commandName) const {
+    if (m_shortcuts.contains(commandName)) {
+        return m_shortcuts[commandName].currentSequence;
+    }
+    return QString();
+}
+
+QString ShortcutManager::getDefaultShortcutString(const QString& commandName) const {
+    if (m_shortcuts.contains(commandName)) {
+        return m_shortcuts[commandName].defaultSequence;
+    }
+    return QString();
+}
+
+QString ShortcutManager::getShortcutDescription(const QString& commandName) const {
+     if (m_shortcuts.contains(commandName)) {
+        return m_shortcuts[commandName].description;
+    }
+    return "Unknown Command";
+}
+
+const QMap<QString, ShortcutInfo>& ShortcutManager::getAllShortcuts() const {
+    return m_shortcuts;
+}
+
+void ShortcutManager::triggerCommand(const QString& commandName) {
+    if (m_shortcuts.contains(commandName) && m_shortcuts[commandName].action) {
+        m_shortcuts[commandName].action->trigger();
+    } else {
+        qWarning() << "ShortcutManager: Cannot trigger. Command" << commandName << "has no action or is not registered.";
+        // Here you could also emit a signal that MainWindow or another component connects to
+        // if the command doesn't have a direct QAction.
+    }
+}
+
+void ShortcutManager::loadShortcuts(const QString& filePath) {
+    m_configFilePath = filePath.isEmpty() ? m_configFilePath : filePath; // Update path if new one provided
+
+    // Use QStandardPaths for user-specific config location
+    QString configDirLocation = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
+    if (configDirLocation.isEmpty()) {
+        qWarning() << "ShortcutManager: Could not determine config directory.";
+        // Fallback to local directory for portable mode or if standard paths fail
+        configDirLocation = QDir::currentPath();
+    }
+    QDir configDir(configDirLocation);
+    if (!configDir.exists()) {
+        configDir.mkpath("."); // Create the directory if it doesn't exist
+    }
+    QString fullPath = configDir.filePath(m_configFilePath);
+    qDebug() << "ShortcutManager: Attempting to load shortcuts from" << fullPath;
+
+
+    QFile file(fullPath);
+    if (!file.exists()) {
+        qInfo() << "ShortcutManager: Shortcut configuration file" << fullPath << "does not exist. Using defaults.";
+        // Apply default sequences to actions if they exist
+        for (const QString& cmdName : m_shortcuts.keys()) {
+            m_shortcuts[cmdName].currentSequence = m_shortcuts[cmdName].defaultSequence;
+            applyShortcutToAction(cmdName, m_shortcuts[cmdName].defaultSequence);
+        } //This ensures actions get their default shortcuts if no config file.
+        return;
+    }
+
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        qWarning() << "ShortcutManager: Could not open shortcut file for reading:" << file.errorString();
+        return;
+    }
+
+    QByteArray jsonData = file.readAll();
+    file.close();
+
+    QJsonParseError parseError;
+    QJsonDocument doc = QJsonDocument::fromJson(jsonData, &parseError);
+    if (parseError.error != QJsonParseError::NoError) {
+        qWarning() << "ShortcutManager: Failed to parse shortcut JSON:" << parseError.errorString();
+        return;
+    }
+
+    if (!doc.isObject()) {
+        qWarning() << "ShortcutManager: Shortcut JSON is not an object.";
+        return;
+    }
+
+    QJsonObject shortcutsObj = doc.object();
+    for (const QString& key : shortcutsObj.keys()) {
+        // Key is the commandName string
+        if (m_shortcuts.contains(key)) { // Check if this command is known (i.e., registered)
+            QString loadedSequence = shortcutsObj[key].toString();
+            if (!loadedSequence.isEmpty()) {
+                m_shortcuts[key].currentSequence = loadedSequence;
+                qDebug() << "ShortcutManager: Loaded shortcut for command" << key
+                         << ":" << loadedSequence;
+                applyShortcutToAction(key, loadedSequence);
+            } else {
+                 // If stored sequence is empty, it means "no shortcut"
+                 m_shortcuts[key].currentSequence = ""; // Explicitly set to empty
+                 applyShortcutToAction(key, ""); // Apply empty shortcut
+                 qDebug() << "ShortcutManager: Empty shortcut for command" << key << "in config. Set to no shortcut.";
+            }
+        } else {
+            qWarning() << "ShortcutManager: Command" << key << "from shortcut file is not registered. Ignoring.";
+        }
+    }
+     qDebug() << "ShortcutManager: Shortcuts loaded successfully from" << fullPath;
+}
+
+void ShortcutManager::saveShortcuts(const QString& filePath) {
+    m_configFilePath = filePath.isEmpty() ? m_configFilePath : filePath;
+
+    QString configDirLocation = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
+     if (configDirLocation.isEmpty()) {
+        qWarning() << "ShortcutManager: Could not determine config directory for saving.";
+        configDirLocation = QDir::currentPath(); // Fallback
+    }
+    QDir configDir(configDirLocation);
+    if (!configDir.exists()) {
+        if (!configDir.mkpath(".")) {
+            qWarning() << "ShortcutManager: Could not create config directory" << configDirLocation;
+            return;
+        }
+    }
+    QString fullPath = configDir.filePath(m_configFilePath);
+    qDebug() << "ShortcutManager: Saving shortcuts to" << fullPath;
+
+    QJsonObject shortcutsObj;
+    for (auto it = m_shortcuts.constBegin(); it != m_shortcuts.constEnd(); ++it) {
+        // Store only if currentSequence differs from default, or store all
+        // Storing all current sequences using their string commandName as key.
+        shortcutsObj[it.key()] = it.value().currentSequence;
+    }
+
+    QJsonDocument doc(shortcutsObj);
+    QFile file(fullPath);
+    if (file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        file.write(doc.toJson(QJsonDocument::Indented));
+        file.close();
+        qDebug() << "ShortcutManager: Shortcuts saved successfully to" << fullPath;
+    } else {
+        qWarning() << "ShortcutManager: Could not open shortcut file for writing:" << file.errorString();
+    }
+}

--- a/src/ShortcutManager.h
+++ b/src/ShortcutManager.h
@@ -1,0 +1,88 @@
+#ifndef SHORTCUTMANAGER_H
+#define SHORTCUTMANAGER_H
+
+#include <QObject>
+#include <QKeySequence>
+#include <QMap>
+#include <QString>
+
+class QAction; // Forward declaration
+
+// Enum to define command identifiers
+enum class CommandId {
+    NEW_FILE,
+    OPEN_FILE,
+    SAVE_FILE,
+    SAVE_AS_FILE,
+    QUIT_APP,
+    TOGGLE_TYPEWRITER_MODE,
+    OPEN_SHORTCUT_SETTINGS,
+    ZEN_MODE,
+    OPEN_SCRATCHPAD
+    // Add more commands as needed
+};
+
+// Helper to convert CommandId to its string representation
+inline QString commandIdToString(CommandId id) {
+    switch (id) {
+        case CommandId::NEW_FILE: return "core.newFile";
+        case CommandId::OPEN_FILE: return "core.openFile";
+        case CommandId::SAVE_FILE: return "core.saveFile";
+        case CommandId::SAVE_AS_FILE: return "core.saveAsFile";
+        case CommandId::QUIT_APP: return "core.quitApp";
+        case CommandId::TOGGLE_TYPEWRITER_MODE: return "core.toggleTypewriterMode";
+        case CommandId::OPEN_SHORTCUT_SETTINGS: return "core.openShortcutSettings";
+        case CommandId::ZEN_MODE: return "core.zenMode";
+        case CommandId::OPEN_SCRATCHPAD: return "core.openScratchpad";
+        default: return "unknown.command";
+    }
+}
+
+// Structure to hold shortcut information
+struct ShortcutInfo {
+    QString commandName;     // Unique string identifier (e.g., "core.newFile", "plugin.myAction")
+    QString defaultSequence; // Default key sequence string
+    QString currentSequence; // Current key sequence string (user-defined or default)
+    QString description;     // User-friendly description for UI
+    QAction* action;         // Associated QAction, if any (can be null)
+
+    ShortcutInfo(QString name = "", QString defSeq = "", QString curSeq = "", QString desc = "", QAction* act = nullptr)
+        : commandName(name), defaultSequence(defSeq), currentSequence(curSeq.isEmpty() ? defSeq : curSeq), description(desc), action(act) {}
+};
+
+class ShortcutManager : public QObject {
+    Q_OBJECT
+
+public:
+    explicit ShortcutManager(QObject *parent = nullptr);
+    ~ShortcutManager();
+
+    void loadShortcuts(const QString& filePath = "shortcuts.json");
+    void saveShortcuts(const QString& filePath = "shortcuts.json");
+
+    // Register using CommandId (for core actions)
+    bool registerCoreShortcut(CommandId id, const QString& defaultSequence, const QString& description, QAction* action = nullptr);
+    // Register using string command name (for plugins or dynamic actions)
+    bool registerNamedShortcut(const QString& commandName, const QString& defaultSequence, const QString& description, QAction* action = nullptr);
+
+    bool updateShortcut(const QString& commandName, const QString& newSequence);
+    QKeySequence getShortcut(const QString& commandName) const;
+    QString getShortcutString(const QString& commandName) const;
+    QString getDefaultShortcutString(const QString& commandName) const;
+    QString getShortcutDescription(const QString& commandName) const;
+    const QMap<QString, ShortcutInfo>& getAllShortcuts() const; // Key is commandName
+
+    void connectToAction(const QString& commandName, QAction* action);
+    void triggerCommand(const QString& commandName);
+
+signals:
+    void shortcutChanged(const QString& commandName, const QKeySequence& newSequence);
+
+private:
+    void initializeDefaultShortcuts();
+    void applyShortcutToAction(const QString& commandName, const QString& sequence);
+    QMap<QString, ShortcutInfo> m_shortcuts; // Key is commandName (e.g., "core.newFile")
+    QString m_configFilePath;
+};
+
+#endif // SHORTCUTMANAGER_H

--- a/src/ShortcutSettingsDialog.cpp
+++ b/src/ShortcutSettingsDialog.cpp
@@ -1,0 +1,301 @@
+#include "ShortcutSettingsDialog.h"
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QTableWidget>
+#include <QPushButton>
+#include <QKeySequenceEdit>
+#include <QMessageBox>
+#include <QDebug>
+#include <QEvent>
+#include <QKeyEvent>
+
+// Custom QKeySequenceEdit that captures key press directly
+class CustomKeySequenceEdit : public QKeySequenceEdit {
+public:
+    CustomKeySequenceEdit(QWidget* parent = nullptr) : QKeySequenceEdit(parent) {
+        // setFocusPolicy(Qt::StrongFocus); // Ensure it can get focus
+    }
+
+protected:
+    // bool event(QEvent *event) override {
+    //     if (event->type() == QEvent::KeyPress || event->type() == QEvent::KeyRelease) {
+    //         QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+    //         int k = keyEvent->key();
+    //         Qt::KeyboardModifiers m = keyEvent->modifiers();
+
+    //         if (keyEvent->type() == QEvent::KeyPress) {
+    //             if (k == Qt::Key_Control || k == Qt::Key_Shift || k == Qt::Key_Alt || k == Qt::Key_Meta) {
+    //                 // Just a modifier pressed, store it
+    //                 currentModifiers = m;
+    //                 setKeySequence(QKeySequence(currentModifiers));
+    //                 return true;
+    //             }
+    //             if (currentModifiers != Qt::NoModifier && k != Qt::Key_unknown) {
+    //                  setKeySequence(QKeySequence(currentModifiers | k));
+    //             } else if (k != Qt::Key_unknown) {
+    //                 setKeySequence(QKeySequence(k));
+    //             }
+    //         } else { // KeyRelease
+    //              if (k == Qt::Key_Control || k == Qt::Key_Shift || k == Qt::Key_Alt || k == Qt::Key_Meta) {
+    //                 // Modifier released
+    //                 if (keySequence()[0] == currentModifiers) { // if only modifier was set
+    //                     // If the sequence was just the modifier, clear it or handle as needed
+    //                 }
+    //                 currentModifiers = Qt::NoModifier; // Reset
+    //              }
+    //         }
+    //         return true;
+    //     }
+    //     return QKeySequenceEdit::event(event);
+    // }
+
+
+// void keyPressEvent(QKeyEvent *event) override {
+//     QKeySequenceEdit::keyPressEvent(event);
+//     if (event->key() == Qt::Key_Backspace && event->modifiers() == Qt::NoModifier) {
+//         clear();
+//     } else {
+//         // This logic is tricky with QKeySequenceEdit as it has its own handling.
+//         // It might be better to use a QLineEdit and parse the input manually,
+//         // or use a dedicated QKeySequenceEdit and handle its editingFinished signal.
+//         // For simplicity, QKeySequenceEdit's default behavior is often sufficient.
+//     }
+// }
+
+private:
+    // Qt::KeyboardModifiers currentModifiers = Qt::NoModifier;
+};
+
+
+ShortcutSettingsDialog::ShortcutSettingsDialog(ShortcutManager* shortcutManager, QWidget *parent)
+    : QDialog(parent), m_shortcutManager(shortcutManager) {
+    if (!m_shortcutManager) {
+        qCritical() << "ShortcutSettingsDialog: ShortcutManager instance is null!";
+        // Handle error appropriately, maybe disable the dialog or throw
+        return;
+    }
+    m_initialShortcuts = m_shortcutManager->getAllShortcuts(); // Store initial state
+    setupUi();
+    populateTable();
+    connectSignals();
+    setWindowTitle("Configure Shortcuts");
+    setMinimumSize(500, 400);
+}
+
+ShortcutSettingsDialog::~ShortcutSettingsDialog() {
+    // Qt handles child widget deletion
+}
+
+void ShortcutSettingsDialog::setupUi() {
+    QVBoxLayout* mainLayout = new QVBoxLayout(this);
+
+    m_shortcutsTable = new QTableWidget(this);
+    m_shortcutsTable->setColumnCount(3); // Command, Current Shortcut, Default Shortcut
+    m_shortcutsTable->setHorizontalHeaderLabels({"Command", "Shortcut", "Default"});
+    m_shortcutsTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
+    m_shortcutsTable->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+    m_shortcutsTable->horizontalHeader()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
+    m_shortcutsTable->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_shortcutsTable->setSelectionMode(QAbstractItemView::SingleSelection);
+    m_shortcutsTable->setEditTriggers(QAbstractItemView::NoEditTriggers); // Initially no direct edit
+    // m_shortcutsTable->setEditTriggers(QAbstractItemView::DoubleClicked); // Enable editing on double click for the shortcut column
+
+    mainLayout->addWidget(m_shortcutsTable);
+
+    QHBoxLayout* buttonsLayout = new QHBoxLayout();
+    m_resetButton = new QPushButton("Reset Selected", this);
+    m_clearButton = new QPushButton("Clear Selected", this);
+    m_applyButton = new QPushButton("Apply", this);
+    m_okButton = new QPushButton("OK", this);
+    m_cancelButton = new QPushButton("Cancel", this);
+
+    buttonsLayout->addWidget(m_resetButton);
+    buttonsLayout->addWidget(m_clearButton);
+    buttonsLayout->addStretch();
+    buttonsLayout->addWidget(m_applyButton);
+    buttonsLayout->addWidget(m_okButton);
+    buttonsLayout->addWidget(m_cancelButton);
+
+    mainLayout->addLayout(buttonsLayout);
+    setLayout(mainLayout);
+}
+
+void ShortcutSettingsDialog::populateTable() {
+    m_shortcutsTable->setRowCount(0); // Clear existing rows
+    m_modifiedShortcuts.clear(); // Clear pending changes
+
+    const auto& allShortcuts = m_shortcutManager->getAllShortcuts();
+    int row = 0;
+    for (auto it = allShortcuts.constBegin(); it != allShortcuts.constEnd(); ++it, ++row) {
+        m_shortcutsTable->insertRow(row);
+
+        const QString& commandName = it.key();
+        const ShortcutInfo& info = it.value();
+
+        QTableWidgetItem* commandItem = new QTableWidgetItem(info.description);
+        commandItem->setData(Qt::UserRole, commandName); // Store commandName (QString)
+        commandItem->setFlags(commandItem->flags() & ~Qt::ItemIsEditable);
+        m_shortcutsTable->setItem(row, 0, commandItem);
+
+        QTableWidgetItem* currentShortcutItem = new QTableWidgetItem(keySequenceToString(QKeySequence::fromString(info.currentSequence, QKeySequence::PortableText)));
+        currentShortcutItem->setFlags(currentShortcutItem->flags() | Qt::ItemIsEditable); // Make this cell editable
+        m_shortcutsTable->setItem(row, 1, currentShortcutItem);
+
+        QTableWidgetItem* defaultShortcutItem = new QTableWidgetItem(keySequenceToString(QKeySequence::fromString(info.defaultSequence, QKeySequence::PortableText)));
+        defaultShortcutItem->setFlags(defaultShortcutItem->flags() & ~Qt::ItemIsEditable);
+        m_shortcutsTable->setItem(row, 2, defaultShortcutItem);
+    }
+    m_shortcutsTable->resizeColumnsToContents();
+    m_shortcutsTable->horizontalHeader()->setSectionResizeMode(0, QHeaderView::Stretch);
+    m_shortcutsTable->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+}
+
+
+void ShortcutSettingsDialog::connectSignals() {
+    connect(m_okButton, &QPushButton::clicked, this, &ShortcutSettingsDialog::onApply);
+    connect(m_okButton, &QPushButton::clicked, this, &QDialog::accept);
+    connect(m_cancelButton, &QPushButton::clicked, this, &QDialog::reject);
+    connect(m_applyButton, &QPushButton::clicked, this, &ShortcutSettingsDialog::onApply);
+    connect(m_resetButton, &QPushButton::clicked, this, &ShortcutSettingsDialog::onResetSelectedShortcut);
+    connect(m_clearButton, &QPushButton::clicked, this, &ShortcutSettingsDialog::onClearSelectedShortcut);
+    // connect(m_shortcutsTable, &QTableWidget::cellChanged, this, &ShortcutSettingsDialog::onShortcutInputCellChanged);
+    connect(m_shortcutsTable, &QTableWidget::cellDoubleClicked, this, &ShortcutSettingsDialog::onCellDoubleClicked);
+}
+
+void ShortcutSettingsDialog::onCellDoubleClicked(int row, int column) {
+    if (column == 1) { // Shortcut column
+        m_shortcutsTable->editItem(m_shortcutsTable->item(row, column));
+        QWidget* editor = m_shortcutsTable->cellWidget(row, column);
+        if (!editor) { // If not already a QKeySequenceEdit, create one
+            CustomKeySequenceEdit* keyEdit = new CustomKeySequenceEdit(m_shortcutsTable);
+            keyEdit->setKeySequence(stringToKeySequence(m_shortcutsTable->item(row, column)->text()));
+            m_shortcutsTable->setCellWidget(row, column, keyEdit);
+            keyEdit->setFocus(); // Give focus to start editing
+            // Connect a signal from the editor to capture the new sequence when editing is finished
+            connect(keyEdit, &QKeySequenceEdit::editingFinished, this, [this, row, keyEdit]() {
+                QKeySequence newSeq = keyEdit->keySequence();
+                QTableWidgetItem* item = m_shortcutsTable->item(row, 1);
+                if (item) {
+                    item->setText(keySequenceToString(newSeq));
+                }
+                // Store this change in m_modifiedShortcuts
+                QString commandName = m_shortcutsTable->item(row, 0)->data(Qt::UserRole).toString();
+                m_modifiedShortcuts[commandName] = newSeq.toString(QKeySequence::PortableText);
+                m_shortcutsTable->removeCellWidget(row, 1); // Remove editor, show text
+            });
+             // Handle Escape key to cancel editing
+            QObject::connect(keyEdit, &QKeySequenceEdit::editingFinished, [=]() {
+                if (keyEdit->keySequence().isEmpty() && keyEdit->property("userCancelled").toBool()) {
+                    // User pressed Esc or cleared it in a way that signifies cancellation
+                    m_shortcutsTable->removeCellWidget(row, 1);
+                    // Optionally revert to original text if needed, though usually editingFinished handles this
+                }
+            });
+        }
+    }
+}
+
+
+void ShortcutSettingsDialog::onShortcutInputCellChanged(int row, int column) {
+    if (column != 1) return; // Only care about the "Shortcut" column
+
+    QTableWidgetItem* commandItem = m_shortcutsTable->item(row, 0);
+    QTableWidgetItem* shortcutCell = m_shortcutsTable->item(row, column);
+    if (!commandItem || !shortcutCell) return;
+
+    QString commandName = commandItem->data(Qt::UserRole).toString();
+    QString newSequenceStr = shortcutCell->text();
+
+    // Validate the new sequence string if necessary (QKeySequence::fromString can do this)
+    // For now, assume valid input or handle validation in onApply
+    m_modifiedShortcuts[commandName] = newSequenceStr; // Store as portable string
+    qDebug() << "Shortcut for" << m_shortcutManager->getShortcutDescription(commandName) << "staged to change to" << newSequenceStr;
+}
+
+
+void ShortcutSettingsDialog::onApply() {
+    bool changesMade = false;
+    for (auto it = m_modifiedShortcuts.constBegin(); it != m_modifiedShortcuts.constEnd(); ++it) {
+        const QString& commandName = it.key();
+        QString newSequenceStr = it.value();
+
+        // Check if it's actually different from the current one in ShortcutManager
+        if (m_shortcutManager->getShortcutString(commandName) != newSequenceStr) {
+            if (m_shortcutManager->updateShortcut(commandName, newSequenceStr)) {
+                qDebug() << "Applied shortcut for" << m_shortcutManager->getShortcutDescription(commandName) << "to" << newSequenceStr;
+                changesMade = true;
+            } else {
+                qWarning() << "Failed to apply shortcut for" << m_shortcutManager->getShortcutDescription(commandName);
+                // Optionally revert this cell in the table or show an error
+            }
+        }
+    }
+
+    if (changesMade) {
+        m_shortcutManager->saveShortcuts(); // Persist all changes
+        m_initialShortcuts = m_shortcutManager->getAllShortcuts(); // Update initial state to current
+        populateTable(); // Refresh table to show current state and clear cell widgets
+        QMessageBox::information(this, "Shortcuts Applied", "Shortcut changes have been applied.");
+    }
+    m_modifiedShortcuts.clear(); // Clear staged changes
+}
+
+void ShortcutSettingsDialog::onResetSelectedShortcut() {
+    QList<QTableWidgetItem*> selectedItems = m_shortcutsTable->selectedItems();
+    if (selectedItems.isEmpty()) {
+        QMessageBox::information(this, "Reset Shortcut", "Please select a command to reset its shortcut.");
+        return;
+    }
+
+    int row = selectedItems.first()->row();
+    QString commandName = m_shortcutsTable->item(row, 0)->data(Qt::UserRole).toString();
+    QString defaultSequenceStr = m_shortcutManager->getDefaultShortcutString(commandName);
+
+    QTableWidgetItem* currentShortcutCell = m_shortcutsTable->item(row, 1);
+    if (currentShortcutCell) {
+        currentShortcutCell->setText(keySequenceToString(QKeySequence::fromString(defaultSequenceStr, QKeySequence::PortableText)));
+        m_modifiedShortcuts[commandName] = defaultSequenceStr; // Stage this change
+        qDebug() << "Shortcut for" << m_shortcutManager->getShortcutDescription(commandName) << "staged to reset to default:" << defaultSequenceStr;
+    }
+}
+
+void ShortcutSettingsDialog::onClearSelectedShortcut() {
+    QList<QTableWidgetItem*> selectedItems = m_shortcutsTable->selectedItems();
+    if (selectedItems.isEmpty()) {
+        QMessageBox::information(this, "Clear Shortcut", "Please select a command to clear its shortcut.");
+        return;
+    }
+
+    int row = selectedItems.first()->row();
+    QString commandName = m_shortcutsTable->item(row, 0)->data(Qt::UserRole).toString();
+
+    QTableWidgetItem* currentShortcutCell = m_shortcutsTable->item(row, 1);
+    if (currentShortcutCell) {
+        currentShortcutCell->setText(""); // Empty string for no shortcut
+        m_modifiedShortcuts[commandName] = "";   // Stage this change (empty string)
+        qDebug() << "Shortcut for" << m_shortcutManager->getShortcutDescription(commandName) << "staged to be cleared.";
+    }
+}
+
+QString ShortcutSettingsDialog::keySequenceToString(const QKeySequence& sequence) {
+    return sequence.toString(QKeySequence::NativeText);
+}
+
+QKeySequence ShortcutSettingsDialog::stringToKeySequence(const QString& string) {
+    return QKeySequence::fromString(string, QKeySequence::NativeText);
+}
+
+// Override reject to handle pending changes
+void ShortcutSettingsDialog::reject() {
+    if (!m_modifiedShortcuts.isEmpty()) {
+        QMessageBox::StandardButton reply;
+        reply = QMessageBox::question(this, "Discard Changes?",
+                                      "You have unsaved shortcut changes. Do you want to discard them?",
+                                      QMessageBox::Yes | QMessageBox::No);
+        if (reply == QMessageBox::No) {
+            return; // Don't close
+        }
+    }
+    QDialog::reject(); // Proceed to close
+}

--- a/src/ShortcutSettingsDialog.h
+++ b/src/ShortcutSettingsDialog.h
@@ -1,0 +1,48 @@
+#ifndef SHORTCUTSETTINGSDIALOG_H
+#define SHORTCUTSETTINGSDIALOG_H
+
+#include <QDialog>
+#include <QMap>
+#include <QKeySequenceEdit>
+#include "ShortcutManager.h" // For CommandId and ShortcutInfo
+
+QT_BEGIN_NAMESPACE
+class QTableWidget;
+class QPushButton;
+class QTableWidgetItem;
+QT_END_NAMESPACE
+
+class ShortcutSettingsDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit ShortcutSettingsDialog(ShortcutManager* shortcutManager, QWidget *parent = nullptr);
+    ~ShortcutSettingsDialog();
+
+private slots:
+    void populateTable();
+    void onApply();
+    void onResetSelectedShortcut();
+    void onClearSelectedShortcut();
+    void onShortcutInputCellChanged(int row, int column);
+    void onCellDoubleClicked(int row, int column);
+
+private:
+    void setupUi();
+    void connectSignals();
+    QString keySequenceToString(const QKeySequence& sequence);
+    QKeySequence stringToKeySequence(const QString& string);
+
+    ShortcutManager* m_shortcutManager;
+    QTableWidget* m_shortcutsTable;
+    QPushButton* m_okButton;
+    QPushButton* m_cancelButton;
+    QPushButton* m_applyButton;
+    QPushButton* m_resetButton;
+    QPushButton* m_clearButton;
+
+    QMap<QString, ShortcutInfo> m_initialShortcuts; // To track changes and revert on cancel. Key: commandName
+    QMap<QString, QString> m_modifiedShortcuts; // To store pending changes. Key: commandName, Value: new shortcut string
+};
+
+#endif // SHORTCUTSETTINGSDIALOG_H


### PR DESCRIPTION
This commit introduces a comprehensive system for managing and customizing keyboard shortcuts within the Alte text editor.

Key features and improvements include:

1.  **ShortcutManager:** A central class (`ShortcutManager`) responsible for registering, loading, saving, and dispatching all application shortcuts. Shortcuts are stored in a `shortcuts.json` file in your application config directory, allowing for persistence.

2.  **Extensible Design:** The ShortcutManager now uses string-based command identifiers (e.g., "core.newFile", "plugin.action") internally and in the JSON configuration. This makes the system more extensible for future plugins and improves the readability of the configuration file.

3.  **Shortcut Settings UI:** A new dialog (`ShortcutSettingsDialog`) allows you to:
    *   View all registered commands and their current/default shortcuts.
    *   Modify existing shortcuts by typing new key sequences.
    *   Reset shortcuts to their default values.
    *   Clear shortcuts for commands.
    This dialog is accessible via the "File" menu and the default shortcut "Ctrl+Alt+S".

4.  **New Shortcut-Enabled Features:**
    *   **Zen Mode:** Activated by "F11" (default), hides UI elements like the menu bar, status bar, and line numbers to provide a distraction-free editing environment.
    *   **Scratchpad:** Activated by "Ctrl+Shift+P" (default), opens a modeless, stay-on-top dialog for quick notes. Scratchpad content is persisted across sessions in `alte_scratchpad.txt`.

5.  **Integration:** Existing actions (New, Open, Save, Typewriter Mode, etc.) have been integrated with the new ShortcutManager.

This overhaul provides you with greater control over your workflow and lays a more robust foundation for future feature additions.